### PR TITLE
fix client updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 - Supports `css` prop with JSX pragma
 - Loads styles on demand
 - Allows shipping CSS in NPM packages
-- `2.1kb` minified and gzipped
+- `2.16kb` minified and gzipped
 
 ## Installation
 

--- a/site/app/FeaturesGrid.tsx
+++ b/site/app/FeaturesGrid.tsx
@@ -46,7 +46,7 @@ const features = [
   {
     title: (
       <>
-        <code className="px-1 rounded bg-pink-50">2.1kb</code> minified &
+        <code className="px-1 rounded bg-pink-50">2.16kb</code> minified &
         gzipped
       </>
     ),

--- a/site/app/examples/ClientComponent.tsx
+++ b/site/app/examples/ClientComponent.tsx
@@ -1,0 +1,22 @@
+'use client'
+import { styled } from 'restyle'
+import { useState } from 'react'
+
+const Button = styled('button', {
+  color: 'dodgerblue',
+  fontSize: '2rem',
+})
+
+export function ClientComponent() {
+  const [on, setOn] = useState(false)
+  return (
+    <Button
+      css={{
+        color: on ? 'green' : 'red',
+      }}
+      onClick={() => setOn(!on)}
+    >
+      {on ? 'On' : 'Off'}
+    </Button>
+  )
+}

--- a/site/app/examples/page.tsx
+++ b/site/app/examples/page.tsx
@@ -1,5 +1,7 @@
 import { css, styled, type CSSProp } from 'restyle'
 
+import { ClientComponent } from './ClientComponent'
+
 export default function Page() {
   return (
     <>
@@ -8,6 +10,9 @@ export default function Page() {
 
       <h2>Precedence</h2>
       <PrecedenceExample />
+
+      <h2>Client Component</h2>
+      <ClientComponent />
     </>
   )
 }


### PR DESCRIPTION
This fixes an issue where styles would never get updates after the initial render and required a full refresh when using `css` or `styled` in a Client Component. The previous mechanism using a constant ref was used initially for performance, but did not end up being viable with fast refresh or client state updates. Now the incoming styles object is checked and updates the cached result if needed.