### PR TITLE
Fix pseudo-classes typo and standardize StyledLink component name

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   - [CSS Function](#css-function)
   - [CSS Prop](#css-prop)
   - [Box Component](#box-component)
-  - [Psuedoclasses](#psuedoclasses)
+  - [Pseudo-classes](#pseudo-classes)
   - [Media Queries](#media-queries)
   - [Child Selectors](#child-selectors)
 - [Acknowledgments](#acknowledgments)
@@ -163,7 +163,7 @@ export default function MyComponent() {
 - [CSS Function](#css-function)
 - [CSS Prop](#css-prop)
 - [Box Component](#box-component)
-- [Psuedoclasses](#psuedoclasses)
+- [Pseudo-classes](#pseudo-classes)
 - [Media Queries](#media-queries)
 - [Child Selectors](#child-selectors)
 
@@ -314,7 +314,7 @@ export function Box({
 }
 ```
 
-### Psuedoclasses
+### Pseudo-classes
 
 ```tsx
 /** @jsxImportSource restyle */

--- a/site/app/Examples.mdx
+++ b/site/app/Examples.mdx
@@ -5,7 +5,7 @@
 - [CSS Function](#css-function)
 - [CSS Prop](#css-prop)
 - [Box Component](#box-component)
-- [Psuedoclasses](#psuedoclasses)
+- [Pseudo-classes](#pseudo-classes)
 - [Media Queries](#media-queries)
 - [Child Selectors](#child-selectors)
 
@@ -17,7 +17,7 @@ The `styled` function is a higher-order function that takes an HTML element tag 
 import Link from 'next/link'
 import { styled } from 'restyle'
 
-const StyleLink = styled(Link, {
+const StyledLink = styled(Link, {
   color: 'rebeccapurple',
   textDecoration: 'none',
 })
@@ -155,7 +155,7 @@ export function Box({
 }
 ```
 
-### Psuedoclasses
+### Pseudo-classes
 
 ```tsx
 /** @jsxImportSource restyle */


### PR DESCRIPTION
Hi! 👋 

I was checking the documentation and the README file (super interesting project!) and I noticed a typo (I propose a fix based on [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes)) and that the `StyledLink` example component was written `StyledLink` in the README file and `StyleLink` in the documentation. Therefore, this PR serves to address these details, if you consider it useful.

Thanks!