### PR TITLE
fix style deduplication

### DIFF
--- a/src/client-styles.tsx
+++ b/src/client-styles.tsx
@@ -1,10 +1,8 @@
 'use client'
 import { useLayoutEffect } from 'react'
 
-import { hash } from './hash'
 import type { CSSRule } from './types'
 
-const cache = new Set<string>()
 let hasRenderedInitialStyles = false
 
 /**
@@ -19,37 +17,13 @@ let hasRenderedInitialStyles = false
  * the first time they are encountered.
  */
 export function ClientStyles({
-  rules,
-  nonce,
+  r: rules,
+  n: nonce,
 }: {
-  rules: CSSRule[]
-  nonce?: string
+  r: [CSSRule[], CSSRule[], CSSRule[]]
+  n?: string
 }) {
-  const rulesLength = rules.length
-  let lowRules = ''
-  let mediumRules = ''
-  let highRules = ''
-
-  for (let index = 0; index < rulesLength; index++) {
-    const [className, rule] = rules[index]!
-
-    if (cache.has(className)) {
-      continue
-    }
-
-    const precedence = className[0]
-
-    if (precedence === 'l') {
-      lowRules += rule
-    } else if (precedence === 'm') {
-      mediumRules += rule
-    } else {
-      highRules += rule
-    }
-  }
-
-  /* Don't send undefined nonce to reduce serialization size */
-  const sharedProps = nonce ? { nonce } : {}
+  const [lowRules, mediumRules, highRules] = rules
 
   /* Only render the initial styles once to establish precedence order */
   if (hasRenderedInitialStyles === false) {
@@ -58,128 +32,70 @@ export function ClientStyles({
     }, [])
   }
 
+  /* Don't send undefined nonce to reduce serialization size */
+  const sharedProps = nonce ? { nonce } : {}
+
   return (
     <>
-      {lowRules.length === 0 && hasRenderedInitialStyles ? null : (
-        <style
-          // @ts-expect-error
-          href={lowRules.length > 0 ? hash(lowRules) : 'rsli'}
-          precedence="rsl"
-          {...sharedProps}
-        >
-          {lowRules}
-        </style>
+      {lowRules.length === 0 ? (
+        hasRenderedInitialStyles ? null : (
+          <style
+            // @ts-expect-error
+            href="rsli"
+            precedence="rsl"
+            {...sharedProps}
+          />
+        )
+      ) : (
+        lowRules.map(([className, rule], index) => (
+          <style
+            // @ts-expect-error
+            href={className}
+            precedence="rsl"
+            key={index}
+            {...sharedProps}
+          >
+            {rule}
+          </style>
+        ))
       )}
 
-      {mediumRules.length === 0 && hasRenderedInitialStyles ? null : (
-        <style
-          // @ts-expect-error
-          href={mediumRules.length > 0 ? hash(mediumRules) : 'rsmi'}
-          precedence="rsm"
-          {...sharedProps}
-        >
-          {mediumRules}
-        </style>
+      {mediumRules.length === 0 ? (
+        hasRenderedInitialStyles ? null : (
+          <style
+            // @ts-expect-error
+            href="rsmi"
+            precedence="rsm"
+            {...sharedProps}
+          />
+        )
+      ) : (
+        mediumRules.map(([className, rule], index) => (
+          <style
+            // @ts-expect-error
+            href={className}
+            precedence="rsm"
+            key={index}
+            {...sharedProps}
+          >
+            {rule}
+          </style>
+        ))
       )}
 
-      {highRules.length > 0 ? (
-        <style
-          // @ts-expect-error
-          href={hash(highRules)}
-          precedence="rsh"
-          {...sharedProps}
-        >
-          {highRules}
-        </style>
-      ) : null}
+      {highRules.length > 0
+        ? highRules.map(([className, rule], index) => (
+            <style
+              // @ts-expect-error
+              href={className}
+              precedence="rsh"
+              key={index}
+              {...sharedProps}
+            >
+              {rule}
+            </style>
+          ))
+        : null}
     </>
   )
-}
-
-/*
- * Since React may have inserted duplicate styles into the DOM due to concurrent
- * rendering, we need to watch and remove duplicate rules as they are added.
- */
-if (typeof window !== 'undefined') {
-  const seenStyleElements = new Set<HTMLStyleElement>()
-  const seenSelectors = new Set<string>()
-
-  function processStyleRule(
-    rule: CSSStyleRule,
-    sheet: CSSStyleSheet,
-    index: number
-  ) {
-    const selector = rule.selectorText
-
-    if (seenSelectors.has(selector)) {
-      sheet.deleteRule(index)
-    } else {
-      seenSelectors.add(selector)
-    }
-
-    const className = selector.match(/\.([a-zA-Z0-9_-]+)/)![1]!
-
-    cache.add(className)
-  }
-
-  function processMediaRule(mediaRule: CSSMediaRule, sheet: CSSStyleSheet) {
-    const rules = mediaRule.cssRules
-
-    for (let index = rules.length - 1; index >= 0; index--) {
-      const rule = rules[index]!
-      if (rule instanceof CSSStyleRule) {
-        processStyleRule(rule, sheet, index)
-      }
-    }
-  }
-
-  function processStyleElement(node: HTMLStyleElement) {
-    const sheet = node.sheet as CSSStyleSheet
-    const rules = sheet.cssRules
-
-    if (rules) {
-      for (let index = rules.length - 1; index >= 0; index--) {
-        const rule = rules[index]!
-
-        if (rule instanceof CSSStyleRule) {
-          processStyleRule(rule, sheet, index)
-        } else if (rule instanceof CSSMediaRule) {
-          processMediaRule(rule, sheet)
-        }
-      }
-    }
-
-    seenStyleElements.add(node)
-  }
-
-  const observer = new MutationObserver((mutations) => {
-    for (
-      let mutationIndex = 0;
-      mutationIndex < mutations.length;
-      mutationIndex++
-    ) {
-      const mutation = mutations[mutationIndex]!
-      const addedNodes = mutation.addedNodes
-
-      for (let nodeIndex = 0; nodeIndex < addedNodes.length; nodeIndex++) {
-        const node = addedNodes[nodeIndex]! as HTMLStyleElement
-
-        if (
-          node.tagName === 'STYLE' &&
-          node.dataset.precedence?.startsWith('rs') &&
-          !seenStyleElements.has(node)
-        ) {
-          processStyleElement(node)
-        }
-      }
-    }
-  })
-
-  document
-    .querySelectorAll<HTMLStyleElement>('style[data-precedence^="rs"]')
-    .forEach((node) => {
-      processStyleElement(node)
-    })
-
-  observer.observe(document.head, { childList: true })
 }

--- a/src/css.tsx
+++ b/src/css.tsx
@@ -129,8 +129,10 @@ function createRules(
   styles: CSSObject,
   selector = '',
   parentSelector = ''
-): [string, CSSRule[]] {
-  const rules: CSSRule[] = []
+): [string, CSSRule[], CSSRule[], CSSRule[]] {
+  const lowRules: CSSRule[] = []
+  const mediumRules: CSSRule[] = []
+  const highRules: CSSRule[] = []
   let classNames = ''
 
   for (const key in styles) {
@@ -154,7 +156,9 @@ function createRules(
       )
 
       classNames += nestedRules[0] + ' '
-      rules.push(...nestedRules[1])
+      lowRules.push(...nestedRules[1])
+      mediumRules.push(...nestedRules[2])
+      highRules.push(...nestedRules[3])
       continue
     }
 
@@ -169,10 +173,16 @@ function createRules(
     )
 
     classNames += className + ' '
-    rules.push([className, rule])
+    if (precedence === 'l') {
+      lowRules.push([className, rule])
+    } else if (precedence === 'm') {
+      mediumRules.push([className, rule])
+    } else {
+      highRules.push([className, rule])
+    }
   }
 
-  return [classNames.trim(), rules]
+  return [classNames.trim(), lowRules, mediumRules, highRules]
 }
 
 /**
@@ -183,10 +193,10 @@ export function css(
   styles: CSSObject,
   nonce?: string
 ): [string, () => React.ReactNode] {
-  const [classNames, rules] = createRules(styles)
+  const [classNames, lowRules, mediumRules, highRules] = createRules(styles)
 
   function Styles() {
-    return <ClientStyles rules={rules} nonce={nonce} />
+    return <ClientStyles r={[lowRules, mediumRules, highRules]} n={nonce} />
   }
 
   return [classNames, Styles]


### PR DESCRIPTION
This fixes style deduplication by rendering a style element per CSS rule which lets React fully handle deduplicating styles. While this will increase the serialization cost, it ensures that styles are only ever injected once. Unfortunately, this also increases the style element count when moving across pages as seen in https://github.com/facebook/react/issues/30739 when used in a Next.js application.

There is currently no way to handle a cache across the server and client that is reliable enough. Once `React.cache` is available on the client this might help with per request deduplication.