### PR TITLE
Consistently use React namespace to use JSX types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -12,8 +12,8 @@ export type CSSRule = [className: string, rule?: string]
 
 type ClassNameMessage = 'Component must accept a className prop'
 
-export type AcceptsClassName<T> = T extends keyof JSX.IntrinsicElements
-  ? 'className' extends keyof JSX.IntrinsicElements[T]
+export type AcceptsClassName<T> = T extends keyof React.JSX.IntrinsicElements
+  ? 'className' extends keyof React.JSX.IntrinsicElements[T]
     ? T
     : ClassNameMessage
   : T extends React.ComponentType<infer P>
@@ -34,7 +34,7 @@ export declare namespace RestyleJSX {
   export type IntrinsicClassAttributes<T> =
     React.JSX.IntrinsicClassAttributes<T>
   export type IntrinsicElements = {
-    [K in keyof JSX.IntrinsicElements]: React.JSX.IntrinsicElements[K] & {
+    [K in keyof React.JSX.IntrinsicElements]: React.JSX.IntrinsicElements[K] & {
       css?: CSSObject
     }
   }


### PR DESCRIPTION
Hello 👋

I'm playing with Restyle recently and I've had small issues while using it with React 19 types. `JSX` namespace is no longer global in the `rc` types for React. It seems the `React.` prefix is used nearly everywhere where accessing it, but there're few places missing which causes TypeScript headaches when using. This PR adds the prefix in few missing places