### PR TITLE
Adjust `media` helper return type

### DIFF
--- a/src/media.ts
+++ b/src/media.ts
@@ -186,5 +186,5 @@ export function media(...queries: (MediaQueryObject | string)[]) {
     }
   }
 
-  return ('@media ' + result) as any
+  return '@media ' + result
 }


### PR DESCRIPTION
Hello 👋

I'm not sure whether that `as any` cast is necessary, but it doesn't break anything for sure and gives the function proper return type in generated types by `tsc`. Decided to just open PR instead of an issue with a question whether cast is necessary, so feel free to lmk if I'm missing something 😃 