### PR TITLE
Adjust logic responsible for cloning elements

### DIFF
--- a/src/create-restyle-props.ts
+++ b/src/create-restyle-props.ts
@@ -26,19 +26,15 @@ export function createRestyleProps(
   if (Styles) {
     const stylesToRender = React.createElement(Styles, { key: 'rss' })
 
-    if (props.children) {
-      if (props.children.constructor === Array) {
-        props.children = props.children.concat(stylesToRender)
-      } else if (typeof props.children === 'object' && 'type' in props.children) {
-        props.children = [
-          React.cloneElement(props.children, { key: 'rse' }),
-          stylesToRender,
-        ]
-      } else {
-        props.children = [props.children, stylesToRender]
-      }
+    if (Array.isArray(props.children)) {
+      props.children = props.children.concat(stylesToRender)
+    } else if (props.children && typeof props.children === 'object' && 'type' in props.children) {
+      props.children = [
+        React.cloneElement(props.children, { key: 'rse' }),
+        stylesToRender,
+      ]
     } else {
-      props.children = stylesToRender
+      props.children = [props.children, stylesToRender]
     }
   }
 

--- a/src/create-restyle-props.ts
+++ b/src/create-restyle-props.ts
@@ -29,13 +29,13 @@ export function createRestyleProps(
     if (props.children) {
       if (props.children.constructor === Array) {
         props.children = props.children.concat(stylesToRender)
-      } else if (typeof props.children === 'string') {
-        props.children = [props.children, stylesToRender]
-      } else {
+      } else if (typeof props.children === 'object' && 'type' in props.children) {
         props.children = [
           React.cloneElement(props.children, { key: 'rse' }),
           stylesToRender,
         ]
+      } else {
+        props.children = [props.children, stylesToRender]
       }
     } else {
       props.children = stylesToRender


### PR DESCRIPTION
Hello, I have another thing that I stumbled upon while playing with Restyle 😃

Current check verifies only whether something is string and in that cases it avoids cloning.  However, besides strings there're many things that are supported as renderable node in React. That makes code like this throw error:

```tsx
<span css={{}}>{5}</span>
<span css={{}}>{5n}</span>
<span css={{}}>{true}</span>
```

And like this with React 19 (context, promises, generators, async iterables are renderable nodes now):

```tsx
<span css={{}}>{Promise.resolve("test")}</span>
<span css={{}}>{React.createContext("anything")}</span>
<span css={{}}>{getAsyncIterator()}</span>
<span css={{}}>{getGenerator()}</span>
```

This is the error:

![image](https://github.com/user-attachments/assets/a0519405-59bd-45a2-a7e2-374398de838e)

I've tried to investigate React source code what's the best way to differentiate whether that's something "renderable" by React, but that logic is [pretty convoluted](https://github.com/facebook/react/blob/33c7bd9ae3b4f998a477fe0ea8ebdf2f2ee8a144/packages/react-reconciler/src/ReactChildFiber.js#L930).

I've came to idea to do it the other way and differentiate whether something is clonable, because that function logic is [much easier](https://github.com/facebook/react/blob/33c7bd9ae3b4f998a477fe0ea8ebdf2f2ee8a144/packages/react/src/jsx/ReactJSXElement.js#L909). I implemented it as a simple check whether something is object and whether has `type` property. This is still not perfect and I'm open for better ideas, but I feel like it's much better than the current one and will only fail in cases where built-in JSX transform would also fail (but at different place). I've also looked through and it seems like the `type` isn't some `implementation details` but it's [official API](https://react.dev/reference/react/cloneElement#returns).

I also have another idea, maybe it’s worth using `react-is` here? 

My current workaround is to just add "space" after the node, so it's handled as array 😅 

```tsx
<span css={{}}>{5} </span>
<span css={{}}>{5n} </span>
<span css={{}}>{true} </span>
```

Also when applying my patch as change in my project and test-driving it, I noticed one more thing (see difference between 1st and 2nd commit).

Stuff like this still wasn't properly rendered because of truthy check:

```tsx
<span css={{}}>{0}</span>
<span css={{}}>{0n}</span>
```

So I adjusted also the truthiness check and I try to mostly give the job of avoiding falsy values back to React