### PR TITLE
depth-based precedence system

### DIFF
--- a/src/client-styles.tsx
+++ b/src/client-styles.tsx
@@ -4,6 +4,7 @@ import { useLayoutEffect } from 'react'
 import type { CSSRule } from './types'
 
 let hasRenderedInitialStyles = false
+type NestedRules = [CSSRule[], CSSRule[], CSSRule[], NestedRules[]]
 
 /**
  * Renders style elements in order of low, medium, and high precedence.
@@ -19,11 +20,13 @@ let hasRenderedInitialStyles = false
 export function ClientStyles({
   r: rules,
   n: nonce,
+  d: depth = 0,
 }: {
-  r: [CSSRule[], CSSRule[], CSSRule[]]
+  r: NestedRules
   n?: string
+  d?: number
 }) {
-  const [lowRules, mediumRules, highRules] = rules
+  const [lowRules, mediumRules, highRules, nested] = rules
 
   /* Only render the initial styles once to establish precedence order */
   if (hasRenderedInitialStyles === false) {
@@ -35,15 +38,31 @@ export function ClientStyles({
   /* Don't send undefined nonce to reduce serialization size */
   const sharedProps = nonce ? { nonce } : {}
 
+  const depthString = depth === 0 ? '' : depth.toString()
+  const levels = {
+    low: `rsl${depthString}`,
+    med: `rsm${depthString}`,
+    high: `rsh${depthString}`,
+  }
+
   return (
     <>
       {lowRules.length === 0 ? (
         hasRenderedInitialStyles ? null : (
-          <style href="rsli" precedence="rsl" {...sharedProps} />
+          <style
+            href={`${levels.low}i`}
+            precedence={levels.low}
+            {...sharedProps}
+          />
         )
       ) : (
         lowRules.map(([className, rule], index) => (
-          <style href={className} precedence="rsl" key={index} {...sharedProps}>
+          <style
+            href={className}
+            precedence={levels.low}
+            key={index}
+            {...sharedProps}
+          >
             {rule}
           </style>
         ))
@@ -51,28 +70,49 @@ export function ClientStyles({
 
       {mediumRules.length === 0 ? (
         hasRenderedInitialStyles ? null : (
-          <style href="rsmi" precedence="rsm" {...sharedProps} />
+          <style
+            href={`${levels.med}i`}
+            precedence={levels.med}
+            {...sharedProps}
+          />
         )
       ) : (
         mediumRules.map(([className, rule], index) => (
-          <style href={className} precedence="rsm" key={index} {...sharedProps}>
+          <style
+            href={className}
+            precedence={levels.med}
+            key={index}
+            {...sharedProps}
+          >
             {rule}
           </style>
         ))
       )}
 
-      {highRules.length > 0
-        ? highRules.map(([className, rule], index) => (
-            <style
-              href={className}
-              precedence="rsh"
-              key={index}
-              {...sharedProps}
-            >
-              {rule}
-            </style>
-          ))
-        : null}
+      {highRules.length === 0 ? (
+        hasRenderedInitialStyles ? null : (
+          <style
+            href={`${levels.high}i`}
+            precedence={levels.high}
+            {...sharedProps}
+          />
+        )
+      ) : (
+        highRules.map(([className, rule], index) => (
+          <style
+            href={className}
+            precedence={levels.high}
+            key={index}
+            {...sharedProps}
+          >
+            {rule}
+          </style>
+        ))
+      )}
+
+      {nested.map((nested, index) => (
+        <ClientStyles key={index} d={depth + 1} n={nonce} r={nested} />
+      ))}
     </>
   )
 }

--- a/src/client-styles.tsx
+++ b/src/client-styles.tsx
@@ -3,7 +3,7 @@ import { useLayoutEffect } from 'react'
 
 import type { CSSRule } from './types'
 
-let hasRenderedInitialStyles = false
+let hasRenderedInitialStylesToDepth = -1
 type NestedRules = [CSSRule[], CSSRule[], CSSRule[], NestedRules[]]
 
 /**
@@ -28,12 +28,14 @@ export function ClientStyles({
 }) {
   const [lowRules, mediumRules, highRules, nested] = rules
 
-  /* Only render the initial styles once to establish precedence order */
-  if (hasRenderedInitialStyles === false) {
-    useLayoutEffect(() => {
-      hasRenderedInitialStyles = true
-    }, [])
-  }
+  /* Only render the initial styles for each depth once to establish precedence order */
+  const hasRenderedThisDepth = hasRenderedInitialStylesToDepth >= depth
+  useLayoutEffect(() => {
+    hasRenderedInitialStylesToDepth = Math.max(
+      depth,
+      hasRenderedInitialStylesToDepth
+    )
+  }, [depth])
 
   /* Don't send undefined nonce to reduce serialization size */
   const sharedProps = nonce ? { nonce } : {}
@@ -48,7 +50,7 @@ export function ClientStyles({
   return (
     <>
       {lowRules.length === 0 ? (
-        hasRenderedInitialStyles ? null : (
+        hasRenderedThisDepth ? null : (
           <style
             href={`${levels.low}i`}
             precedence={levels.low}
@@ -69,7 +71,7 @@ export function ClientStyles({
       )}
 
       {mediumRules.length === 0 ? (
-        hasRenderedInitialStyles ? null : (
+        hasRenderedThisDepth ? null : (
           <style
             href={`${levels.med}i`}
             precedence={levels.med}
@@ -90,7 +92,7 @@ export function ClientStyles({
       )}
 
       {highRules.length === 0 ? (
-        hasRenderedInitialStyles ? null : (
+        hasRenderedThisDepth ? null : (
           <style
             href={`${levels.high}i`}
             precedence={levels.high}

--- a/src/css.tsx
+++ b/src/css.tsx
@@ -12,10 +12,13 @@ export function css(
   styles: CSSObject,
   nonce?: string
 ): [string, () => React.ReactNode] {
-  const [classNames, lowRules, mediumRules, highRules] = createRules(styles)
+  const [classNames, lowRules, mediumRules, highRules, nested] =
+    createRules(styles)
 
   function Styles() {
-    return <ClientStyles r={[lowRules, mediumRules, highRules]} n={nonce} />
+    return (
+      <ClientStyles r={[lowRules, mediumRules, highRules, nested]} n={nonce} />
+    )
   }
 
   return [classNames, Styles]


### PR DESCRIPTION
this adds style "depth" to the precedence system use by restyle. deeper styles, e.g. media queries, will have higher precedence than shallower styles. The deeper the style is nested, the higher its precedence.

rsl, rsm, and rsh are where are base styles would go:
```javascript
const A = styled("div", {
    background: "green",
})
```

styles nested one level deep go into layers rsl1, rsm1, and rsh1
```javascript
const A = styled("div", {
    "@media (max-width: 600px)": {
        background: "yellow",
    },
})
```

more levels are created as needed. for example, this class would go into rsl2
```javascript
const A = styled("div", {
    "&": {
        "&": {
            background: "red",
        },
    },
})
```

this has the added benefit of reducing the impact of property order. for example, this element would previously have always been green due to class ordering:
```javascript
const A = styled("div", {
    "@media (max-width: 600px)": {
        background: "yellow",
    },
    background: "green",
})
```
using this depth-based system the nested media query always takes higher precedence regardless of property order

using precedence layers like this would let react handle the orchestration of classes in a way that retains their priority, while also clarifying how restyle handles multiple conflicting styles - "deeper styles win"

fixes #23 

