### PR TITLE
Add textarea in voidElements

### DIFF
--- a/src/create-restyle-props.ts
+++ b/src/create-restyle-props.ts
@@ -2,7 +2,7 @@ import * as React from 'react'
 
 import { css } from './index'
 
-const voidElements = new Set(['br', 'embed', 'hr', 'img', 'input'])
+const voidElements = new Set(['br', 'embed', 'hr', 'img', 'input', 'textarea'])
 
 /** Create a `restyle` JSX props object that handles the `css` prop to generate atomic class names. */
 export function createRestyleProps(


### PR DESCRIPTION
Hi, thanks for creating a useful CSS-in-JS package 🎉 

[`<textarea>` does not accept children](https://react.dev/reference/react-dom/components/textarea). However, because `voidElements` does not consider this, `props.children = stylesToRender` is executed in [L41](https://github.com/mimorisuzuko/restyle/blob/main/src/create-restyle-props.ts#L41). As a result, ``Error: Use the `defaultValue` or `value` props instead of setting children on <textarea>.`` is thrown, and styles are not correctly applied to `<textarea>`.

This issue can be reproduced with the following code. The background of this `<textarea>` do not become red as expected.

```tsx
<textarea css={{ background: "red" }} defaultValue="" />
```

So, I added `<textarea>` in `voidElements`. Please feel free to share your feedback or suggestions!