### PR TITLE
Fix children selector

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -105,7 +105,7 @@ export function createRule(
   } else if (selector.includes('&')) {
     className = selector.replace('&', '.' + name)
   } else {
-    className = '.' + name + selector
+    className = '.' + name + (selector.startsWith(":") ? selector: ' ' + selector)
   }
 
   const hyphenProp = prop.replace(/[A-Z]|^ms/g, '-$&').toLowerCase()


### PR DESCRIPTION
I wrote the following code:

```tsx
<div css={{ input: { backgroundColor: "red" } }}>
  <input defaultValue="" type='text' />
</div>
```

This generated the following style, combining `className` and `selector` without spaces.

```css
.ht3a2hginput{background-color:red}
```

To fix this issue, I added a space before `selector` when it is not a pseudo-selector.