### PR TITLE
Fix React-children validation

### DIFF
--- a/src/create-restyle-props.ts
+++ b/src/create-restyle-props.ts
@@ -26,10 +26,10 @@ export function createRestyleProps(
   if (Styles) {
     const stylesToRender = React.createElement(Styles, { key: 'rss' })
 
-    if (props.children) {
+    if (React.Children.count(props.children)) {
       if (props.children.constructor === Array) {
         props.children = props.children.concat(stylesToRender)
-      } else if (typeof props.children === 'string') {
+      } else if (!React.isValidElement(props.children)) {
         props.children = [props.children, stylesToRender]
       } else {
         props.children = [


### PR DESCRIPTION
When `<div css={{ color: "red" }}>{0}</div>` is written, `props.children` is `0` (falsy) and `props.children` is omitted and not rendered. This issue can be fixed with `React.Children.count`. (btw, in `<div css={{ color: "red" }}>{null}</div>`, `React.Children.count(props.children) === 0` works as expected.)

Even if the above is fixed, checking `typeof props.children === 'string'` throws another issue, because `typeof props.children === 'number'`. So, I also used `React.isValidElement`.