### PR TITLE
types: improve the types returned by styled

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           node-version: '20'
 
+      - run: npm install -g corepack
       - run: corepack enable
       - run: corepack pnpm install
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 dist
 node_modules
 out
-
+tsconfig.vitest-temp.json

--- a/package.json
+++ b/package.json
@@ -98,5 +98,12 @@
   "engines": {
     "node": ">=20.0.0"
   },
-  "packageManager": "pnpm@9.15.4"
+  "packageManager": "pnpm@10.1.0+sha512.c89847b0667ddab50396bbbd008a2a43cf3b581efd59cf5d9aa8923ea1fb4b8106c041d540d08acb095037594d73ebc51e1ec89ee40c88b30b8a66c0fae0ac1b",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "msw",
+      "sharp"
+    ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "build": "tsc",
     "dev": "pnpm build --watch",
     "build:site": "pnpm -F site build",
-    "test": "vitest",
+    "test": "vitest --typecheck",
     "prepublishOnly": "pnpm test run",
     "prepare": "pnpm run build"
   },
@@ -92,7 +92,7 @@
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "typescript": "^5.7.3",
-    "vitest": "^3.0.4",
+    "vitest": "3.0.4",
     "vitest-browser-react": "^0.0.4"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,7 +39,7 @@ importers:
         specifier: ^5.7.3
         version: 5.7.3
       vitest:
-        specifier: ^3.0.4
+        specifier: 3.0.4
         version: 3.0.4(@types/debug@4.1.12)(@types/node@20.17.9)(@vitest/browser@3.0.4)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.3))
       vitest-browser-react:
         specifier: ^0.0.4

--- a/src/styled.test-d.tsx
+++ b/src/styled.test-d.tsx
@@ -1,0 +1,242 @@
+import { expectTypeOf, test } from 'vitest'
+import { styled } from './styled.js'
+import type { FC } from 'react'
+
+test('basic component type is preserved', () => {
+  const component = ({
+    className,
+    name,
+  }: {
+    className: string
+    name: string
+  }) => <div className={className}>{name}</div>
+  const extended = styled(component, {})
+
+  expectTypeOf(extended).toMatchTypeOf<typeof component>()
+})
+
+test('additional property types are added', () => {
+  const component = ({
+    className,
+    name,
+  }: {
+    className: string
+    name: string
+  }) => <div className={className}>{name}</div>
+  const extended = styled(component, ({ color }: { color: string }) => ({
+    color,
+  }))
+
+  expectTypeOf(extended).toMatchTypeOf<
+    FC<{
+      className: string
+      name: string
+      color: string
+    }>
+  >()
+})
+
+test('style props are filtered from the component props', () => {
+  const component = ({
+    className,
+    color,
+  }: {
+    className: string
+    color?: number
+  }) => <div className={className}>{color}</div>
+  const extended = styled(component, ({ color }: { color: string }) => ({
+    color,
+  }))
+
+  expectTypeOf(extended).toMatchTypeOf<
+    FC<{
+      className: string
+      color: string
+    }>
+  >()
+})
+
+test('style props are not allowed to break the component type', () => {
+  const component = ({
+    className,
+    color,
+  }: {
+    className: string
+    color: number
+  }) => <div className={className}>{color}</div>
+
+  // @ts-expect-error extending with color would make color always undefined, which is a type error (color must be a number)
+  const extended = styled(component, ({ color }: { color: string }) => ({
+    color,
+  }))
+})
+
+test('extra properties are not allowed', () => {
+  const Component = ({ className }: { className: string }) => (
+    <div className={className} />
+  )
+  const Extended = styled(Component, { color: 'red' })
+  const ExtendedWithProps = styled(
+    Extended,
+    ({ color }: { color: string }) => ({
+      color,
+    })
+  )
+
+  // @ts-expect-error name does not exist on type
+  const basicTest = <Extended className="abc" name="abc" />
+  // @ts-expect-error name does not exist on type
+  const propsTest = <ExtendedWithProps className="abc" name="abc" color="red" />
+})
+
+test('extra properties are permitted if style props allow them', () => {
+  const Component = ({ className }: { className: string }) => (
+    <div className={className} />
+  )
+  const Extended = styled(Component, { color: 'red' })
+  const ExtendedWithProps = styled(
+    Extended,
+    ({ color }: { [key: string]: string }) => ({
+      color,
+    })
+  )
+
+  // @ts-expect-error name does not exist on type
+  const basicTest = <Extended className="abc" name="abc" />
+  const propsTest = <ExtendedWithProps className="abc" name="abc" color="red" />
+})
+
+test('style props are required to be a record', () => {
+  const component = ({ className }: { className: string }) => (
+    <div className={className} />
+  )
+
+  // allowed
+  styled(component, (props: unknown) => ({ color: 'red' }))
+  styled(component, (props: never) => ({ color: 'red' }))
+
+  // disallowed
+  // @ts-expect-error
+  styled(component, (props: number) => ({ color: 'red' }))
+  // @ts-expect-error
+  styled(component, (props: string) => ({ color: 'red' }))
+  // @ts-expect-error
+  styled(component, (props: Map<string, string>) => ({ color: 'red' }))
+  // @ts-expect-error
+  styled(component, (props: []) => ({ color: 'red' }))
+  // @ts-expect-error
+  styled(component, (props: Set<string>) => ({ color: 'red' }))
+  // @ts-expect-error
+  styled(component, (props: undefined) => ({ color: 'red' }))
+  // @ts-expect-error
+  styled(component, (props: null) => ({ color: 'red' }))
+  // @ts-expect-error
+  styled(component, (props: object) => ({ color: 'red' }))
+  // @ts-expect-error
+  styled(component, (props: { color: string } | undefined) => ({
+    color: 'red',
+  }))
+})
+
+/**
+ * In a truly perfect world, styled would be able to preserve
+ * any generic types of the component passed to it.
+ *
+ * i do not believe this is possible in typescript yet,
+ * although there is probably some hacky workaround to be found
+ */
+
+// test('generic types are preserved without style props', () => {
+//   const Component = <SomeText extends string>({
+//     id,
+//     one,
+//     two,
+//     className,
+//   }: {
+//     id: `id-${SomeText}`
+//     one: NoInfer<SomeText>
+//     two: NoInfer<SomeText>
+//     className?: string
+//   }) => <></>
+//   const Extended = styled(Component)
+
+//   const test = (
+//     <>
+//       <Component<'abc'> id="id-abc" one="abc" two="abc" />
+//       <Extended<'abc'> id="id-abc" one="abc" two="abc" />
+//     </>
+//   )
+//   Component({
+//     id: 'id-abc',
+//     one: 'abc',
+//     // @ts-expect-error types require 'abc'
+//     two: 'xyz',
+//   })
+//   Extended({
+//     id: 'id-abc',
+//     one: 'abc',
+//     // @ts-expect-error types require 'abc'
+//     two: 'xyz',
+//   })
+// })
+
+// test('generic types are preserved with style props', () => {
+//   const component = <SomeText extends string>({
+//     id,
+//     one,
+//     two,
+//     className,
+//   }: {
+//     id: `id-${SomeText}`
+//     one: NoInfer<SomeText>
+//     two: NoInfer<SomeText>
+//     className?: string
+//   }) => <></>
+//   const extended = styled(component, ({ color }: { color: string }) => ({
+//     color,
+//   }))
+
+//   component({
+//     id: 'id-abc',
+//     one: 'abc',
+//     // @ts-expect-error types require 'abc'
+//     two: 'xyz',
+//   })
+//   extended({
+//     color: 'red',
+//     id: 'id-abc',
+//     one: 'abc',
+//     // @ts-expect-error types require 'abc'
+//     two: 'xyz',
+//   })
+// })
+
+// test('generic types are preserved even when partially overwritten by style props', () => {
+//   const component = <SomeText extends string>({
+//     id,
+//     one,
+//     two,
+//     className,
+//   }: {
+//     id: `id-${SomeText}`
+//     one?: NoInfer<SomeText>
+//     two: NoInfer<SomeText>
+//     className?: string
+//   }) => <></>
+//   const extended = styled(component, ({ one }: { one: string }) => ({
+//     color: one,
+//   }))
+
+//   component({
+//     id: 'id-abc',
+//     one: 'abc',
+//     // @ts-expect-error types require 'abc'
+//     two: 'xyz',
+//   })
+//   extended({
+//     id: 'id-abc',
+//     one: 'xyz', // <- allowable because the type comes from style props
+//     // @ts-expect-error types require 'abc'
+//     two: 'xyz',
+//   })
+// })

--- a/src/styled.tsx
+++ b/src/styled.tsx
@@ -6,6 +6,7 @@ import type {
   CompatibleProps,
   CSSObject,
   RestrictToRecord,
+  SimpleFunctionComponent,
 } from './types.js'
 import type { JSX } from './jsx-runtime.js'
 
@@ -16,28 +17,62 @@ import type { JSX } from './jsx-runtime.js'
  *
  * Note, the provided component must accept a `className` prop.
  */
-export function styled<ComponentType extends React.ElementType, StyleProps>(
-  Component: AcceptsClassName<ComponentType>,
+export function styled<Props extends { className?: string }, StyleProps>(
+  Component: SimpleFunctionComponent<Props>,
   styles?:
     | CSSObject
     | ((
         // style props will be omitted from the props passed to the component
         // so we need to ensure that we won't break the type the component expects
         props: CompatibleProps<
-          ComponentType,
-          // style props cannot be extend from Record without unintended consequences
+          NoInfer<Props>,
+          // style props cannot extend from Record without unintended consequences
           // so we restrict them here instead
           RestrictToRecord<StyleProps>
         >
       ) => CSSObject)
-): (
-  props: Omit<React.ComponentProps<ComponentType>, keyof StyleProps> &
-    StyleProps & {
-      className?: string
-      css?: CSSObject
-    }
-) => JSX.Element {
-  return ({ className: classNameProp, css: cssProp, ...props }) => {
+): SimpleFunctionComponent<
+  Omit<Props, keyof StyleProps> & {
+    css?: CSSObject
+    className?: string
+  } & StyleProps
+>
+
+// in order to preserve generic types, the signatures for function and intrinsic/class components must be entirely separate
+// having any sort of union type for `Component` will break generic types
+export function styled<TagName extends keyof JSX.IntrinsicElements, StyleProps>(
+  Component:
+    | AcceptsClassName<TagName>
+    | React.ComponentClass<{ className?: string }>,
+  styles?:
+    | CSSObject
+    | ((
+        // see above
+        props: CompatibleProps<
+          React.ComponentProps<TagName>,
+          // see above
+          RestrictToRecord<StyleProps>
+        >
+      ) => CSSObject)
+): SimpleFunctionComponent<
+  Omit<React.ComponentProps<TagName>, keyof StyleProps> & {
+    css?: CSSObject
+    className?: string
+  } & StyleProps
+>
+
+export function styled(
+  Component: string | SimpleFunctionComponent<unknown>,
+  styles?: CSSObject | ((props: unknown) => CSSObject)
+) {
+  return ({
+    className: classNameProp,
+    css: cssProp,
+    ...props
+  }: {
+    className?: string
+    css?: CSSObject
+  }) => {
     let parsedStyles: CSSObject
 
     if (typeof styles === 'function') {
@@ -49,12 +84,7 @@ export function styled<ComponentType extends React.ElementType, StyleProps>(
         },
       })
 
-      parsedStyles = styles(
-        proxyProps as CompatibleProps<
-          ComponentType,
-          RestrictToRecord<StyleProps>
-        >
-      )
+      parsedStyles = styles(proxyProps)
 
       // Filter out accessed props from the original props
       accessedProps.forEach((prop) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,11 @@ export type CSSValue = CSSObject[keyof CSSObject]
 
 export type CSSRule = [className: string, rule?: string]
 
+/**
+ * using the built-in react types won't let us preserve generic component types
+ */
+export type SimpleFunctionComponent<P> = (props: P) => React.JSX.Element
+
 type ClassNameMessage = 'Component must accept a className prop'
 
 export type AcceptsClassName<T> = T extends keyof React.JSX.IntrinsicElements
@@ -27,26 +32,26 @@ export type AcceptsClassName<T> = T extends keyof React.JSX.IntrinsicElements
 type IncompatiblePropsMessage =
   "Specified style props are incompatible with component props. Style props are filtered out of the component's props before being passed."
 
-export type CompatibleProps<
-  ComponentType extends React.ElementType,
-  StyleProps,
-> = [string] extends [keyof StyleProps]
-  ? StyleProps & React.ComponentProps<ComponentType>
-  : Omit<
-        React.ComponentProps<ComponentType>,
-        keyof StyleProps
-      > extends React.ComponentProps<ComponentType>
-    ? StyleProps
-    : IncompatiblePropsMessage
+export type CompatibleProps<ComponentProps, StyleProps> =
+  // check if style props is a wide type like Record<string, unknown>
+  [string] extends [keyof StyleProps]
+    ? // if the type is wide, a simple intersection works nicely
+      StyleProps & ComponentProps
+    : // for narrower types, we can omit properties for a stronger type
+      Omit<ComponentProps, keyof StyleProps> extends ComponentProps
+      ? StyleProps
+      : IncompatiblePropsMessage
 
 type RestrictToRecordMessage =
   'Style props must extend type `Record<string, unknown>`'
 
-export type RestrictToRecord<T> = T extends string
-  ? Record<never, never>
-  : T extends Record<string, unknown>
-    ? T
-    : RestrictToRecordMessage
+export type RestrictToRecord<T> =
+  // our error message is assignable to string, so handle it separately
+  T extends string
+    ? Record<never, never>
+    : T extends Record<string, unknown>
+      ? T
+      : RestrictToRecordMessage
 
 export declare namespace RestyleJSX {
   export type Element = React.JSX.Element

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,30 @@ export type AcceptsClassName<T> = T extends keyof React.JSX.IntrinsicElements
       : ClassNameMessage
     : ClassNameMessage
 
+type IncompatiblePropsMessage =
+  "Specified style props are incompatible with component props. Style props are filtered out of the component's props before being passed."
+
+export type CompatibleProps<
+  ComponentType extends React.ElementType,
+  StyleProps,
+> = [string] extends [keyof StyleProps]
+  ? StyleProps & React.ComponentProps<ComponentType>
+  : Omit<
+        React.ComponentProps<ComponentType>,
+        keyof StyleProps
+      > extends React.ComponentProps<ComponentType>
+    ? StyleProps
+    : IncompatiblePropsMessage
+
+type RestrictToRecordMessage =
+  'Style props must extend type `Record<string, unknown>`'
+
+export type RestrictToRecord<T> = T extends string
+  ? Record<never, never>
+  : T extends Record<string, unknown>
+    ? T
+    : RestrictToRecordMessage
+
 export declare namespace RestyleJSX {
   export type Element = React.JSX.Element
   export type ElementType = React.JSX.ElementType

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
 
     /* If transpiling with TypeScript: */
     "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "outDir": "dist",
     "sourceMap": true,
 


### PR DESCRIPTION
improvements, in no particular order:

- style props are filtered from the component props
if we were to use a style prop that already existed on the component, our type would not reflect it
```typescript
const Sample= styled('div', ({ onClick }: { onClick: string }) => ({
  color: onClick,
}))
```
in this example, previously `onClick` was `MouseEventHandler<HTMLDivElement> & string`, but because style props are filtered, a more correct type is just `string`

- style props are not allowed to break the component type
because style props are filtered, if a required component prop and a style prop share a name we now get a type error

```typescript
const component = ({
  className,
  color,
}: {
  className: string
  color: number
}) => <div className={className}>{color}</div>

// @ts-expect-error extending with color would make color always undefined, but color must be a number
const extended = styled(component, ({ color }: { color: string }) => ({
  color,
}))
```

- extra properties are not allowed
previously, if style props was a function our component props were expanded to `Record<string, unknown>` which would let us add incorrect props
```typescript
const Extended = styled(
  Extended2,
  ({ color }: { color: string }) => ({
    color,
  })
)

const test= (
  <Extended
    className="abc"
    // @ts-expect-error name does not exist on type, but previously was allowed anyway
    name="abc"
  />
)
```

- generic types are preserved
this also adds support for generic type propagation, so if we style a generic function component the generic will be preserved. do note that generic class components will not be propagated, only generic function components.
```typescript
const Component = <SomeText extends string>({
  id,
  className,
}: {
  id: `id-${SomeText}`
  className?: string
}) => <div></div>
const Extended = styled(Component, { color: 'red' })

const example= (
  <>
    <Component<'abc'> id="id-abc" />
    {/* our generic is preserved! previously was a type error */}
    <Extended<'abc'> id="id-abc" color="red" />
  </>
)
```