### PR TITLE
simplify styled types

### DIFF
--- a/src/styled.test-d.tsx
+++ b/src/styled.test-d.tsx
@@ -78,6 +78,32 @@ test('style props are filtered from the component props', () => {
   >()
 })
 
+test('style props are allowed to override the component type', () => {
+  const component = ({
+    className,
+    color,
+  }: {
+    className: string
+    color: number
+  }) => <div className={className}>{color}</div>
+
+  const Component = styled(component, ({ color }: { color: string }) => ({
+    color,
+  }))
+
+  const App = () => <Component className="abc" color="red" />
+
+  const Button = styled(
+    'button',
+    (styleProps: { disabled: boolean }, props) => {
+      styleProps.disabled
+      // @ts-expect-error disabled is treated as a style prop so it's won't be forwarded to the component
+      props.disabled
+      return {}
+    }
+  )
+})
+
 test('extra properties are not allowed', () => {
   const Component = ({ className }: { className: string }) => (
     <div className={className} />
@@ -347,7 +373,6 @@ test('generic types are preserved even when partially overwritten by style props
   })
   extended({
     id: 'id-abc',
-    // @ts-expect-error preserved type even when overwritten by style props
     one: 'xyz',
     // @ts-expect-error types require 'abc'
     two: 'xyz',

--- a/src/styled.tsx
+++ b/src/styled.tsx
@@ -3,12 +3,9 @@ import * as React from 'react'
 import { css } from './css.js'
 import type {
   AcceptsClassName,
-  CompatibleProps,
   CSSObject,
-  DistributiveOmit,
-  MaybeAsyncFunctionComponent,
-  RestrictToRecord,
-  StyledOutput,
+  FunctionComponent,
+  StyledElement,
 } from './types.js'
 import type { JSX } from './jsx-runtime.js'
 
@@ -19,50 +16,45 @@ import type { JSX } from './jsx-runtime.js'
  *
  * Note, the provided component must accept a `className` prop.
  */
-export function styled<Props extends { className?: string }, StyleProps>(
-  Component: MaybeAsyncFunctionComponent<Props>,
+export function styled<
+  Props extends { className?: string },
+  StyleProps extends object,
+>(
+  Component: FunctionComponent<Props>,
   styles?:
     | CSSObject
-    | ((
-        // style props will be omitted from the props passed to the component
-        // so we need to ensure that we won't break the type the component expects
-        styleProps: CompatibleProps<
-          NoInfer<Props>,
-          // style props cannot extend from Record without unintended consequences
-          // so we restrict them here instead
-          RestrictToRecord<StyleProps>
-        >,
-        props: NoInfer<Props>
-      ) => CSSObject)
-): StyledOutput<
-  DistributiveOmit<Props, keyof StyleProps> & {
-    css?: CSSObject
-    className?: string
-  } & StyleProps
+    | ((styleProps: StyleProps, props: NoInfer<Props>) => CSSObject)
+): StyledElement<
+  Props &
+    StyleProps & {
+      css?: CSSObject
+      className?: string
+    }
 >
 
-export function styled<TagName extends keyof JSX.IntrinsicElements, StyleProps>(
+export function styled<
+  TagName extends keyof JSX.IntrinsicElements,
+  StyleProps extends object,
+>(
   Component:
     | AcceptsClassName<TagName>
     | React.ComponentClass<{ className?: string }>,
   styles?:
     | CSSObject
     | ((
-        styleProps: CompatibleProps<
-          React.ComponentProps<TagName>,
-          RestrictToRecord<StyleProps>
-        >,
+        styleProps: StyleProps,
         props: React.ComponentProps<TagName>
       ) => CSSObject)
-): StyledOutput<
-  DistributiveOmit<React.ComponentProps<TagName>, keyof StyleProps> & {
-    css?: CSSObject
-    className?: string
-  } & StyleProps
+): StyledElement<
+  React.ComponentProps<TagName> &
+    StyleProps & {
+      css?: CSSObject
+      className?: string
+    }
 >
 
 export function styled(
-  Component: string | MaybeAsyncFunctionComponent<unknown>,
+  Component: string | FunctionComponent<unknown>,
   styles?: CSSObject | ((styleProps: unknown, props: unknown) => CSSObject)
 ) {
   return ({

--- a/src/styled.tsx
+++ b/src/styled.tsx
@@ -5,6 +5,7 @@ import type {
   AcceptsClassName,
   CSSObject,
   FunctionComponent,
+  NoOverlap,
   StyledElement,
 } from './types.js'
 import type { JSX } from './jsx-runtime.js'
@@ -23,14 +24,11 @@ export function styled<
   Component: FunctionComponent<Props>,
   styles?:
     | CSSObject
-    | ((styleProps: StyleProps, props: NoInfer<Props>) => CSSObject)
-): StyledElement<
-  Props &
-    StyleProps & {
-      css?: CSSObject
-      className?: string
-    }
->
+    | ((
+        styleProps: NoOverlap<StyleProps, Props>,
+        props: NoInfer<Props>
+      ) => CSSObject)
+): StyledElement<Props & StyleProps>
 
 export function styled<
   TagName extends keyof JSX.IntrinsicElements,
@@ -42,21 +40,18 @@ export function styled<
   styles?:
     | CSSObject
     | ((
-        styleProps: StyleProps,
+        styleProps: NoOverlap<StyleProps, React.ComponentProps<TagName>>,
         props: React.ComponentProps<TagName>
       ) => CSSObject)
-): StyledElement<
-  React.ComponentProps<TagName> &
-    StyleProps & {
-      css?: CSSObject
-      className?: string
-    }
->
+): StyledElement<React.ComponentProps<TagName> & StyleProps>
 
 export function styled(
-  Component: string | FunctionComponent<unknown>,
-  styles?: CSSObject | ((styleProps: unknown, props: unknown) => CSSObject)
-) {
+  Component:
+    | AcceptsClassName<any>
+    | React.ComponentClass<{ className?: string }>
+    | FunctionComponent<any>,
+  styles?: CSSObject | ((styleProps: any, props: any) => CSSObject)
+): StyledElement<any> {
   return ({
     className: classNameProp,
     css: cssProp,
@@ -98,7 +93,6 @@ export function styled(
 
     return (
       <>
-        {/* @ts-expect-error */}
         <Component className={className} {...props} />
         <Styles />
       </>

--- a/src/styled.tsx
+++ b/src/styled.tsx
@@ -5,8 +5,8 @@ import type {
   AcceptsClassName,
   CSSObject,
   FunctionComponent,
-  NoOverlap,
-  StyledElement,
+  StyleResolver,
+  StyledComponent,
 } from './types.js'
 import type { JSX } from './jsx-runtime.js'
 
@@ -22,13 +22,8 @@ export function styled<
   StyleProps extends object,
 >(
   Component: FunctionComponent<Props>,
-  styles?:
-    | CSSObject
-    | ((
-        styleProps: NoOverlap<StyleProps, Props>,
-        props: NoInfer<Props>
-      ) => CSSObject)
-): StyledElement<Props & StyleProps>
+  styles?: CSSObject | StyleResolver<StyleProps, Props>
+): StyledComponent<Props & StyleProps>
 
 export function styled<
   TagName extends keyof JSX.IntrinsicElements,
@@ -37,13 +32,8 @@ export function styled<
   Component:
     | AcceptsClassName<TagName>
     | React.ComponentClass<{ className?: string }>,
-  styles?:
-    | CSSObject
-    | ((
-        styleProps: NoOverlap<StyleProps, React.ComponentProps<TagName>>,
-        props: React.ComponentProps<TagName>
-      ) => CSSObject)
-): StyledElement<React.ComponentProps<TagName> & StyleProps>
+  styles?: CSSObject | StyleResolver<StyleProps, React.ComponentProps<TagName>>
+): StyledComponent<React.ComponentProps<TagName> & StyleProps>
 
 export function styled(
   Component:
@@ -51,7 +41,7 @@ export function styled(
     | React.ComponentClass<{ className?: string }>
     | FunctionComponent<any>,
   styles?: CSSObject | ((styleProps: any, props: any) => CSSObject)
-): StyledElement<any> {
+): StyledComponent<any> {
   return ({
     className: classNameProp,
     css: cssProp,

--- a/src/styled.tsx
+++ b/src/styled.tsx
@@ -4,6 +4,7 @@ import { css } from './css.js'
 import type {
   AcceptsClassName,
   CSSObject,
+  DistributiveOmit,
   FunctionComponent,
   StyleResolver,
   StyledComponent,
@@ -23,7 +24,7 @@ export function styled<
 >(
   Component: FunctionComponent<Props>,
   styles?: CSSObject | StyleResolver<StyleProps, Props>
-): StyledComponent<Props & StyleProps>
+): StyledComponent<DistributiveOmit<Props, keyof StyleProps> & StyleProps>
 
 export function styled<
   TagName extends keyof JSX.IntrinsicElements,
@@ -33,7 +34,9 @@ export function styled<
     | AcceptsClassName<TagName>
     | React.ComponentClass<{ className?: string }>,
   styles?: CSSObject | StyleResolver<StyleProps, React.ComponentProps<TagName>>
-): StyledComponent<React.ComponentProps<TagName> & StyleProps>
+): StyledComponent<
+  DistributiveOmit<React.ComponentProps<TagName>, keyof StyleProps> & StyleProps
+>
 
 export function styled(
   Component:

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,12 +16,12 @@ export type FunctionComponent<Props> = (
   props: Props
 ) => React.ReactNode | Promise<React.ReactNode>
 
-export type NoOverlap<StyleProps, Props> = keyof StyleProps &
-  keyof Props extends never
-  ? StyleProps
-  : 'Error: Overlapping keys not allowed'
+export type StyleResolver<StyleProps extends object, Props extends object> = (
+  styleProps: StyleProps,
+  props: Props
+) => CSSObject
 
-export type StyledElement<Props> = (
+export type StyledComponent<Props> = (
   props: Props & {
     css?: CSSObject
     className?: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,13 +12,11 @@ export type CSSValue = CSSObject[keyof CSSObject]
 
 export type CSSRule = [className: string, rule?: string]
 
-/**
- * using the built-in react types won't let us preserve generic component types
- */
-export type MaybeAsyncFunctionComponent<P> = (
-  props: P
+export type FunctionComponent<Props> = (
+  props: Props
 ) => React.ReactNode | Promise<React.ReactNode>
-export type StyledOutput<P> = (props: P) => React.JSX.Element
+
+export type StyledElement<Props> = (props: Props) => React.JSX.Element
 
 type ClassNameMessage = 'Component must accept a className prop'
 
@@ -31,76 +29,6 @@ export type AcceptsClassName<T> = T extends keyof React.JSX.IntrinsicElements
       ? T
       : ClassNameMessage
     : ClassNameMessage
-
-type FilteredRequiredPropErrorMessage<Keys extends PropertyKey> =
-  `Error: Styles function filters prop(s) '${Extract<Keys, string>}' which are explicitly named in style props and required by the original component.`
-
-/**
- * Omit over a union of types without merging them
- */
-export type DistributiveOmit<T, K extends keyof any> = T extends any
-  ? Omit<T, K>
-  : never
-
-/**
- * extract keys from T that are explicitly named
- * (excludes string/number index signatures)
- */
-type KnownKeys<T> = keyof {
-  [K in keyof T as string extends K
-    ? never
-    : number extends K
-      ? never
-      : K]: T[K]
-}
-
-/**
- * extract keys of required properties from T
- */
-type RequiredKeys<T> = {
-  [K in keyof T]-?: {} extends Pick<T, K> ? never : K
-}[keyof T]
-
-/**
- * check if any required component props overlap with ONLY the
- * style prop keys
- *
- * This ignores potential conflicts via index signatures
- * unless the key is also explicitly named in StyleProps
- */
-type RequiredKnownKeyFiltered<CompProps, StyleProps> =
-  Extract<RequiredKeys<CompProps>, KnownKeys<StyleProps>> extends never
-    ? false // No required component prop conflicts with a KNOWN style prop key
-    : true // A required component prop conflicts with a KNOWN style prop key
-
-/**
- * Calculates the compatible props for a styled component considering runtime filtering
- */
-export type CompatibleProps<ComponentProps, StyleProps> =
-  StyleProps extends never
-    ? ComponentProps
-    : // check if any required ComponentProps conflict with explicitly named (Known) StyleProps keys
-      RequiredKnownKeyFiltered<ComponentProps, StyleProps> extends true
-      ? // if conflict with KNOWN keys, return error
-        FilteredRequiredPropErrorMessage<
-          Extract<RequiredKeys<ComponentProps>, KnownKeys<StyleProps>>
-        >
-      : // if NO conflict with KNOWN keys, calculate props:
-        //   - start with ComponentProps
-        //   - remove properties explicitly named in StyleProps
-        //   - add all StyleProps (which includes potential index signatures)
-        Omit<ComponentProps, KnownKeys<StyleProps>> & StyleProps
-
-type RestrictToRecordMessage =
-  'Style props must extend type `Record<string, unknown>`'
-
-export type RestrictToRecord<T> =
-  // our error message is assignable to string, so handle it separately
-  T extends string
-    ? Record<never, never>
-    : T extends Record<string, unknown>
-      ? T
-      : RestrictToRecordMessage
 
 export declare namespace RestyleJSX {
   export type Element = React.JSX.Element

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,7 +16,17 @@ export type FunctionComponent<Props> = (
   props: Props
 ) => React.ReactNode | Promise<React.ReactNode>
 
-export type StyledElement<Props> = (props: Props) => React.JSX.Element
+export type NoOverlap<StyleProps, Props> = keyof StyleProps &
+  keyof Props extends never
+  ? StyleProps
+  : 'Error: Overlapping keys not allowed'
+
+export type StyledElement<Props> = (
+  props: Props & {
+    css?: CSSObject
+    className?: string
+  }
+) => React.JSX.Element
 
 type ClassNameMessage = 'Component must accept a className prop'
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,7 @@ export type FunctionComponent<Props> = (
 
 export type StyleResolver<StyleProps extends object, Props extends object> = (
   styleProps: StyleProps,
-  props: Props
+  props: DistributiveOmit<Props, keyof StyleProps>
 ) => CSSObject
 
 export type StyledComponent<Props> = (
@@ -39,6 +39,10 @@ export type AcceptsClassName<T> = T extends keyof React.JSX.IntrinsicElements
       ? T
       : ClassNameMessage
     : ClassNameMessage
+
+export type DistributiveOmit<Type, Keys extends keyof any> = Type extends any
+  ? Omit<Type, Keys>
+  : never
 
 export declare namespace RestyleJSX {
   export type Element = React.JSX.Element


### PR DESCRIPTION
This simplifies the styled types now that component/element props are separated since 769621c. This makes it more straightforward to type the styled utility implementation since the user should provide the style props type directly so we don't need to try filtering them against the incoming props.

This was overstrict previously (imo) where it's not clear how to handle something like this:

```tsx
import { styled } from 'restyle'

const Button = styled('button', (styleProps) => ({
  color: styleProps.color // technically error since color is a valid attribute and collides with style props
}))
```

Likewise, when composing custom components it's easy for these to clash when you may actually want to filter the prop and use it for styling:

```tsx
import { styled } from 'restyle'

const Button = styled('button', { color: '#222' })
const ExtendedButton = styled(Button, (styleProps) => ({
  color: styleProps.color // similarly Button accepts a color attribute from inheriting all HTMLElement attributes which clashes
}))
```

This let's the author have more flexibility when choosing to not forward a potential valid prop and use it as a style prop like in the cases above. Since defining style props isn't a common occurrence and mostly one and done inside a design system I think this is ok to be more flexible here.

There is a case for doing something similar to styled-components and emotion and introducing a `shouldForwardProp` option, but I think that starts to add too much complexity and the `css` utility should be used directly to type custom utilities in these cases.

cc @RJWadley