### PR TITLE
improve hash performance

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -7,14 +7,14 @@ describe('createRules', () => {
     const result = createRules({ color: 'red' })
     expect(result).toMatchInlineSnapshot(`
       [
-        "h1oa3ggs",
+        "hh45au7",
         [
           [],
           [],
           [
             [
-              "h1oa3ggs",
-              ".h1oa3ggs{color:red}",
+              "hh45au7",
+              ".hh45au7{color:red}",
             ],
           ],
           [],
@@ -27,7 +27,7 @@ describe('createRules', () => {
     const result = createRules({ '[data-theme]& span': { color: 'red' } })
     expect(result).toMatchInlineSnapshot(`
       [
-        "htvdw3y",
+        "h1jb4e15",
         [
           [],
           [],
@@ -38,8 +38,8 @@ describe('createRules', () => {
               [],
               [
                 [
-                  "htvdw3y",
-                  "[data-theme].htvdw3y span{color:red}",
+                  "h1jb4e15",
+                  "[data-theme].h1jb4e15 span{color:red}",
                 ],
               ],
               [],

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -69,25 +69,13 @@ const m = new Set([
 const u =
   /^(-|f[lo].*[^se]$|g.{5,}[^ps]$|z|o[pr]|(W.{5})?[lL]i.*(t|mp)$|an|(bo|s).{4}Im|sca|m.{6}[ds]|ta|c.*[st]$|wido|ini)/
 
-/** Hash a string into a base36 encoded string. */
-export function hash(str: string): string {
-  // FNV-1a Hash Function
-  let h = 0 ^ 0x811c9dc5
-  for (let index = 0; index < str.length; index++) {
-    h ^= str.charCodeAt(index)
-    h = (h * 0x01000193) >>> 0
+/** Hash a string using the djb2 algorithm. */
+export function hash(value: string): string {
+  let hash = 5381
+  for (let index = 0; index < value.length; index++) {
+    hash = ((hash << 5) + hash + value.charCodeAt(index)) >>> 0
   }
-
-  // Base36 Encoding Function
-  const letters = 'abcdefghijklmnopqrstuvwxyz'
-  const base36 = '0123456789' + letters
-  let result = ''
-  do {
-    result = base36[h % 36] + result
-    h = Math.floor(h / 36)
-  } while (h > 0)
-
-  return result
+  return hash.toString(36)
 }
 
 /** Create a single CSS rule from a CSS object. */


### PR DESCRIPTION
Improves hashing performance to be approximately 31.72% faster when comparing both [hash algorithms](https://gist.github.com/souporserious/cbedfad6c378bf8920dc5520169f96c0) by using a [djb2](http://www.cse.yorku.ca/~oz/hash.html) algorithm. h/t to [unplugin-parcel-macros](https://github.com/devongovett/unplugin-parcel-macros/blob/aa1c6793be6baec17211236ed24c64d20c5b6202/examples/next/macro.js).