### PR TITLE
proof of concept: manage composition

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,20 +87,20 @@
     "@types/mdx": "^2.0.13",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",
-    "@vitejs/plugin-react": "^4.3.4",
-    "@vitest/browser": "^3.0.5",
-    "playwright": "^1.50.1",
-    "prettier": "^3.4.2",
+    "@vitejs/plugin-react": "^4.4.1",
+    "@vitest/browser": "^3.1.2",
+    "playwright": "^1.52.0",
+    "prettier": "^3.5.3",
     "react": "19.0.0",
     "react-dom": "19.0.0",
-    "typescript": "^5.7.3",
-    "vitest": "3.0.5",
-    "vitest-browser-react": "^0.0.4"
+    "typescript": "^5.8.3",
+    "vitest": "3.1.2",
+    "vitest-browser-react": "^0.1.1"
   },
   "engines": {
     "node": ">=20.0.0"
   },
-  "packageManager": "pnpm@10.1.0",
+  "packageManager": "pnpm@10.10.0",
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,17 +18,17 @@ importers:
         specifier: ^19.0.3
         version: 19.0.3(@types/react@19.0.8)
       '@vitejs/plugin-react':
-        specifier: ^4.3.4
-        version: 4.3.4(vite@5.4.11(@types/node@20.17.9)(lightningcss@1.29.1))
+        specifier: ^4.4.1
+        version: 4.4.1(vite@5.4.11(@types/node@20.17.9)(lightningcss@1.29.1))
       '@vitest/browser':
-        specifier: ^3.0.5
-        version: 3.0.5(@types/node@20.17.9)(playwright@1.50.1)(typescript@5.7.3)(vite@5.4.11(@types/node@20.17.9)(lightningcss@1.29.1))(vitest@3.0.5)
+        specifier: ^3.1.2
+        version: 3.1.2(msw@2.7.0(@types/node@20.17.9)(typescript@5.8.3))(playwright@1.52.0)(vite@5.4.11(@types/node@20.17.9)(lightningcss@1.29.1))(vitest@3.1.2)
       playwright:
-        specifier: ^1.50.1
-        version: 1.50.1
+        specifier: ^1.52.0
+        version: 1.52.0
       prettier:
-        specifier: ^3.4.2
-        version: 3.4.2
+        specifier: ^3.5.3
+        version: 3.5.3
       react:
         specifier: 19.0.0
         version: 19.0.0
@@ -36,14 +36,14 @@ importers:
         specifier: 19.0.0
         version: 19.0.0(react@19.0.0)
       typescript:
-        specifier: ^5.7.3
-        version: 5.7.3
+        specifier: ^5.8.3
+        version: 5.8.3
       vitest:
-        specifier: 3.0.5
-        version: 3.0.5(@types/debug@4.1.12)(@types/node@20.17.9)(@vitest/browser@3.0.5)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.3))
+        specifier: 3.1.2
+        version: 3.1.2(@types/debug@4.1.12)(@types/node@20.17.9)(@vitest/browser@3.1.2)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.8.3))
       vitest-browser-react:
-        specifier: ^0.0.4
-        version: 0.0.4(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(@vitest/browser@3.0.5(@types/node@20.17.9)(playwright@1.50.1)(typescript@5.7.3)(vite@5.4.11(@types/node@20.17.9)(lightningcss@1.29.1))(vitest@3.0.5))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(vitest@3.0.5(@types/debug@4.1.12)(@types/node@20.17.9)(@vitest/browser@3.0.5)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.3)))
+        specifier: ^0.1.1
+        version: 0.1.1(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(@vitest/browser@3.1.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(vitest@3.1.2)
 
   jsx-dev-runtime: {}
 
@@ -62,10 +62,10 @@ importers:
         version: 15.1.6(@mdx-js/loader@3.1.0(acorn@8.14.0))(@mdx-js/react@3.1.0(@types/react@19.0.8)(react@19.0.0))
       '@vercel/analytics':
         specifier: ^1.4.1
-        version: 1.4.1(next@15.1.6(@babel/core@7.26.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
+        version: 1.4.1(next@15.1.6(@babel/core@7.27.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
       next:
         specifier: 15.1.6
-        version: 15.1.6(@babel/core@7.26.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 15.1.6(@babel/core@7.27.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react:
         specifier: 19.0.0
         version: 19.0.0
@@ -106,28 +106,32 @@ packages:
     resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/compat-data@7.26.5':
-    resolution: {integrity: sha512-XvcZi1KWf88RVbF9wn8MN6tYFloU5qX8KjuF3E1PVBmJ9eypXfs4GRiJwLuTZL0iSnJUKn1BFPa5BPZZJyFzPg==}
+  '@babel/code-frame@7.27.1':
+    resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/core@7.26.0':
-    resolution: {integrity: sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==}
+  '@babel/compat-data@7.27.1':
+    resolution: {integrity: sha512-Q+E+rd/yBzNQhXkG+zQnF58e4zoZfBedaxwzPmicKsiK3nt8iJYrSrDbjwFFDGC4f+rPafqRaPH6TsDoSvMf7A==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@7.26.5':
-    resolution: {integrity: sha512-2caSP6fN9I7HOe6nqhtft7V4g7/V/gfDsC3Ag4W7kEzzvRGKqiv0pu0HogPiZ3KaVSoNDhUws6IJjDjpfmYIXw==}
+  '@babel/core@7.27.1':
+    resolution: {integrity: sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-compilation-targets@7.26.5':
-    resolution: {integrity: sha512-IXuyn5EkouFJscIDuFF5EsiSolseme1s0CZB+QxVugqJLYmKdxI1VfIBOst0SUu4rnk2Z7kqTwmoO1lp3HIfnA==}
+  '@babel/generator@7.27.1':
+    resolution: {integrity: sha512-UnJfnIpc/+JO0/+KRVQNGU+y5taA5vCbwN8+azkX6beii/ZF+enZJSOKo11ZSzGJjlNfJHfQtmQT8H+9TXPG2w==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-module-imports@7.25.9':
-    resolution: {integrity: sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==}
+  '@babel/helper-compilation-targets@7.27.1':
+    resolution: {integrity: sha512-2YaDd/Rd9E598B5+WIc8wJPmWETiiJXFYVE60oX8FDohv7rAUU3CQj+A1MgeEmcsk2+dQuEjIe/GDvig0SqL4g==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-module-transforms@7.26.0':
-    resolution: {integrity: sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==}
+  '@babel/helper-module-imports@7.27.1':
+    resolution: {integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.27.1':
+    resolution: {integrity: sha512-9yHn519/8KvTU5BjTVEEeIM3w9/2yXNKoD82JifINImhpKkARMJKPP59kLo+BafpdN5zgNeIcS4jsGDmd3l58g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -140,20 +144,33 @@ packages:
     resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.25.9':
     resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-option@7.25.9':
-    resolution: {integrity: sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==}
+  '@babel/helper-validator-identifier@7.27.1':
+    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helpers@7.26.0':
-    resolution: {integrity: sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==}
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.27.1':
+    resolution: {integrity: sha512-FCvFTm0sWV8Fxhpp2McP5/W53GPllQ9QeQ7SiqGWjMf/LVG07lFa5+pgK05IRhVwtvafT22KF+ZSnM9I545CvQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/parser@7.26.5':
     resolution: {integrity: sha512-SRJ4jYmXRqV1/Xc+TIVG84WjHBXKlxO9sHQnA2Pf12QQEAp1LOh6kDzNHXcUnbH1QI0FDoPPVOt+vyUDucxpaw==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.27.1':
+    resolution: {integrity: sha512-I0dZ3ZpCrJ1c04OqlNsQcKiZlsrXf/kkE4FXzID9rIOYICsAbA8mMDzhW/luRNAHdCNt7os/u8wenklZDlUVUQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -173,16 +190,20 @@ packages:
     resolution: {integrity: sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/template@7.25.9':
-    resolution: {integrity: sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==}
+  '@babel/template@7.27.1':
+    resolution: {integrity: sha512-Fyo3ghWMqkHHpHQCoBs2VnYjR4iWFFjguTDEqA5WgZDOrFesVjMhMM2FSqTKSoUSDO1VQtavj8NFpdRBEvJTtg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/traverse@7.26.5':
-    resolution: {integrity: sha512-rkOSPOw+AXbgtwUga3U4u8RpoK9FEFWBNAlTpcnkLFjL5CT+oyHNuUUC/xx6XefEJ16r38r8Bc/lfp6rYuHeJQ==}
+  '@babel/traverse@7.27.1':
+    resolution: {integrity: sha512-ZCYtZciz1IWJB4U61UPu4KEaqyfj+r5T1Q5mqPo+IBpcG9kHv30Z0aD8LXPgC1trYa6rK0orRyAhqUgk4MjmEg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.26.5':
     resolution: {integrity: sha512-L6mZmwFDK6Cjh1nRCLXpa6no13ZIioJDz7mdkzHv399pThrTa/k0nUlNaenOeh2kWu/iaOQYElEpKPUswUa9Vg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.27.1':
+    resolution: {integrity: sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==}
     engines: {node: '>=6.9.0'}
 
   '@bundled-es-modules/cookie@2.0.1':
@@ -828,19 +849,19 @@ packages:
       vue-router:
         optional: true
 
-  '@vitejs/plugin-react@4.3.4':
-    resolution: {integrity: sha512-SCCPBJtYLdE8PX/7ZQAs1QAZ8Jqwih+0VBLum1EGqmCCQal+MIUqLCzj3ZUy8ufbC0cAM4LRlSTm7IQJwWT4ug==}
+  '@vitejs/plugin-react@4.4.1':
+    resolution: {integrity: sha512-IpEm5ZmeXAP/osiBXVVP5KjFMzbWOonMs0NaQQl+xYnUAcq4oHUBsF2+p4MgKWG4YMmFYJU8A6sxRPuowllm6w==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0
 
-  '@vitest/browser@3.0.5':
-    resolution: {integrity: sha512-5WAWJoucuWcGYU5t0HPBY03k9uogbUEIu4pDmZHoB4Dt+6pXqzDbzEmxGjejZSitSYA3k/udYfuotKNxETVA3A==}
+  '@vitest/browser@3.1.2':
+    resolution: {integrity: sha512-dwL6hQg3NSDP3Z4xzIZL0xHq/AkQAPQ4StFpWVlY2zbRJtK3Y2YqdFZ7YmZjszTETN1BDQZRn/QOrcP+c8ATgg==}
     peerDependencies:
       playwright: '*'
       safaridriver: '*'
-      vitest: 3.0.5
-      webdriverio: '*'
+      vitest: 3.1.2
+      webdriverio: ^7.0.0 || ^8.0.0 || ^9.0.0
     peerDependenciesMeta:
       playwright:
         optional: true
@@ -849,11 +870,11 @@ packages:
       webdriverio:
         optional: true
 
-  '@vitest/expect@3.0.5':
-    resolution: {integrity: sha512-nNIOqupgZ4v5jWuQx2DSlHLEs7Q4Oh/7AYwNyE+k0UQzG7tSmjPXShUikn1mpNGzYEN2jJbTvLejwShMitovBA==}
+  '@vitest/expect@3.1.2':
+    resolution: {integrity: sha512-O8hJgr+zREopCAqWl3uCVaOdqJwZ9qaDwUP7vy3Xigad0phZe9APxKhPcDNqYYi0rX5oMvwJMSCAXY2afqeTSA==}
 
-  '@vitest/mocker@3.0.5':
-    resolution: {integrity: sha512-CLPNBFBIE7x6aEGbIjaQAX03ZZlBMaWwAjBdMkIf/cAn6xzLTiM3zYqO/WAbieEjsAZir6tO71mzeHZoodThvw==}
+  '@vitest/mocker@3.1.2':
+    resolution: {integrity: sha512-kOtd6K2lc7SQ0mBqYv/wdGedlqPdM/B38paPY+OwJ1XiNi44w3Fpog82UfOibmHaV9Wod18A09I9SCKLyDMqgw==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^5.0.0 || ^6.0.0
@@ -863,20 +884,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@3.0.5':
-    resolution: {integrity: sha512-CjUtdmpOcm4RVtB+up8r2vVDLR16Mgm/bYdkGFe3Yj/scRfCpbSi2W/BDSDcFK7ohw8UXvjMbOp9H4fByd/cOA==}
+  '@vitest/pretty-format@3.1.2':
+    resolution: {integrity: sha512-R0xAiHuWeDjTSB3kQ3OQpT8Rx3yhdOAIm/JM4axXxnG7Q/fS8XUwggv/A4xzbQA+drYRjzkMnpYnOGAc4oeq8w==}
 
-  '@vitest/runner@3.0.5':
-    resolution: {integrity: sha512-BAiZFityFexZQi2yN4OX3OkJC6scwRo8EhRB0Z5HIGGgd2q+Nq29LgHU/+ovCtd0fOfXj5ZI6pwdlUmC5bpi8A==}
+  '@vitest/runner@3.1.2':
+    resolution: {integrity: sha512-bhLib9l4xb4sUMPXnThbnhX2Yi8OutBMA8Yahxa7yavQsFDtwY/jrUZwpKp2XH9DhRFJIeytlyGpXCqZ65nR+g==}
 
-  '@vitest/snapshot@3.0.5':
-    resolution: {integrity: sha512-GJPZYcd7v8QNUJ7vRvLDmRwl+a1fGg4T/54lZXe+UOGy47F9yUfE18hRCtXL5aHN/AONu29NGzIXSVFh9K0feA==}
+  '@vitest/snapshot@3.1.2':
+    resolution: {integrity: sha512-Q1qkpazSF/p4ApZg1vfZSQ5Yw6OCQxVMVrLjslbLFA1hMDrT2uxtqMaw8Tc/jy5DLka1sNs1Y7rBcftMiaSH/Q==}
 
-  '@vitest/spy@3.0.5':
-    resolution: {integrity: sha512-5fOzHj0WbUNqPK6blI/8VzZdkBlQLnT25knX0r4dbZI9qoZDf3qAdjoMmDcLG5A83W6oUUFJgUd0EYBc2P5xqg==}
+  '@vitest/spy@3.1.2':
+    resolution: {integrity: sha512-OEc5fSXMws6sHVe4kOFyDSj/+4MSwst0ib4un0DlcYgQvRuYQ0+M2HyqGaauUMnjq87tmUaMNDxKQx7wNfVqPA==}
 
-  '@vitest/utils@3.0.5':
-    resolution: {integrity: sha512-N9AX0NUoUtVwKwy21JtwzaqR5L5R5A99GAbrHfCCXK1lp593i/3AZAXhSP43wRQuxYsflrdzEfXZFo1reR1Nkg==}
+  '@vitest/utils@3.1.2':
+    resolution: {integrity: sha512-5GGd0ytZ7BH3H6JTj9Kw7Prn1Nbg0wZVrIvou+UWxm54d+WoXXgAgjFJ8wn3LdagWLFSEfpPeyYrByZaGEZHLg==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -991,8 +1012,8 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
-  chai@5.1.2:
-    resolution: {integrity: sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==}
+  chai@5.2.0:
+    resolution: {integrity: sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==}
     engines: {node: '>=12'}
 
   chalk@4.1.2:
@@ -1209,8 +1230,8 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
-  expect-type@1.1.0:
-    resolution: {integrity: sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==}
+  expect-type@1.2.1:
+    resolution: {integrity: sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==}
     engines: {node: '>=12.0.0'}
 
   extend@3.0.2:
@@ -1225,6 +1246,14 @@ packages:
 
   fault@2.0.1:
     resolution: {integrity: sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==}
+
+  fdir@6.4.4:
+    resolution: {integrity: sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -1513,6 +1542,9 @@ packages:
 
   loupe@3.1.2:
     resolution: {integrity: sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==}
+
+  loupe@3.1.3:
+    resolution: {integrity: sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==}
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
@@ -1840,8 +1872,8 @@ packages:
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
-  pathe@2.0.2:
-    resolution: {integrity: sha512-15Ztpk+nov8DR524R4BF7uEuzESgzUEAV4Ah7CUMNGXdE5ELuvxElxGXndBl32vMSsWa1jpNf22Z+Er3sKwq+w==}
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   pathval@2.0.0:
     resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
@@ -1854,6 +1886,10 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
+  picomatch@4.0.2:
+    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
+
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
@@ -1862,13 +1898,13 @@ packages:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
 
-  playwright-core@1.50.1:
-    resolution: {integrity: sha512-ra9fsNWayuYumt+NiM069M6OkcRb1FZSK8bgi66AtpFoWkg2+y0bJSNmkFrWhMbEBbVKC/EruAHH3g0zmtwGmQ==}
+  playwright-core@1.52.0:
+    resolution: {integrity: sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.50.1:
-    resolution: {integrity: sha512-G8rwsOQJ63XG6BbKj2w5rHeavFjy5zynBA9zsJMMtBoe/Uf757oG12NXz6e6OirF7RCrTVAKFXbLmn1RbL7Qaw==}
+  playwright@1.52.0:
+    resolution: {integrity: sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1925,8 +1961,8 @@ packages:
     resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
     engines: {node: ^10 || ^12 || >=14}
 
-  prettier@3.4.2:
-    resolution: {integrity: sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==}
+  prettier@3.5.3:
+    resolution: {integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -1962,8 +1998,8 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
-  react-refresh@0.14.2:
-    resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
   react@19.0.0:
@@ -2136,8 +2172,8 @@ packages:
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
 
-  sirv@3.0.0:
-    resolution: {integrity: sha512-BPwJGUeDaDCHihkORDchNyyTvWFhcusy1XMmhEVTQTwGeybFbp8YEmB+njbPnth1FibULBSBVwCQni25XlCUDg==}
+  sirv@3.0.1:
+    resolution: {integrity: sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A==}
     engines: {node: '>=18'}
 
   smog-formula@1.0.5:
@@ -2167,8 +2203,8 @@ packages:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
 
-  std-env@3.8.0:
-    resolution: {integrity: sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==}
+  std-env@3.9.0:
+    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
   stemmer@1.0.5:
     resolution: {integrity: sha512-SLq7annzSKRDStasOJJoftCSCzBCKmBmH38jC4fDtCunAqOzpTpIm9zmaHmwNJiZ8gLe9qpVdBVbEG2DC5dE2A==}
@@ -2254,6 +2290,10 @@ packages:
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
+  tinyglobby@0.2.13:
+    resolution: {integrity: sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==}
+    engines: {node: '>=12.0.0'}
+
   tinypool@1.0.2:
     resolution: {integrity: sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -2315,8 +2355,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.7.3:
-    resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
+  typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -2417,8 +2457,8 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  vite-node@3.0.5:
-    resolution: {integrity: sha512-02JEJl7SbtwSDJdYS537nU6l+ktdvcREfLksk/NDAqtdKWGqHl+joXzEubHROmS3E6pip+Xgu2tFezMu75jH7A==}
+  vite-node@3.1.2:
+    resolution: {integrity: sha512-/8iMryv46J3aK13iUXsei5G/A3CUlW4665THCPS+K8xAaqrVWiGB4RfXMQXCLjpK9P2eK//BczrVkn5JLAk6DA==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
@@ -2453,8 +2493,8 @@ packages:
       terser:
         optional: true
 
-  vitest-browser-react@0.0.4:
-    resolution: {integrity: sha512-4uK8zgo5eHlhrBVEPX8ejRt8Bn4gzV6OZFTPdb1en3FtgjEhhst400XkIQHUC875Q90rOO5Tc4zPpCl8YXvoxg==}
+  vitest-browser-react@0.1.1:
+    resolution: {integrity: sha512-n9l+sIAexKqqfBuEkjVGdfZ4xAn1Gn/+wc4Mo8KsUSUOVoM9evSY0rVXdMIzCQqloT/zvmFGAtziFINkqu+t7g==}
     engines: {node: ^18.0.0 || >=20.0.0}
     peerDependencies:
       '@types/react': '>18.0.0'
@@ -2469,16 +2509,16 @@ packages:
       '@types/react-dom':
         optional: true
 
-  vitest@3.0.5:
-    resolution: {integrity: sha512-4dof+HvqONw9bvsYxtkfUp2uHsTN9bV2CZIi1pWgoFpL1Lld8LA1ka9q/ONSsoScAKG7NVGf2stJTI7XRkXb2Q==}
+  vitest@3.1.2:
+    resolution: {integrity: sha512-WaxpJe092ID1C0mr+LH9MmNrhfzi8I65EX/NRU/Ld016KqQNRgxSOlGNP1hHN+a/F8L15Mh8klwaF77zR3GeDQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/debug': ^4.1.12
       '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.0.5
-      '@vitest/ui': 3.0.5
+      '@vitest/browser': 3.1.2
+      '@vitest/ui': 3.1.2
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -2521,6 +2561,18 @@ packages:
 
   ws@8.18.0:
     resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.18.1:
+    resolution: {integrity: sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -2577,20 +2629,26 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/compat-data@7.26.5': {}
+  '@babel/code-frame@7.27.1':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.27.1
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
 
-  '@babel/core@7.26.0':
+  '@babel/compat-data@7.27.1': {}
+
+  '@babel/core@7.27.1':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@babel/code-frame': 7.26.2
-      '@babel/generator': 7.26.5
-      '@babel/helper-compilation-targets': 7.26.5
-      '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.0)
-      '@babel/helpers': 7.26.0
-      '@babel/parser': 7.26.5
-      '@babel/template': 7.25.9
-      '@babel/traverse': 7.26.5
-      '@babel/types': 7.26.5
+      '@babel/code-frame': 7.27.1
+      '@babel/generator': 7.27.1
+      '@babel/helper-compilation-targets': 7.27.1
+      '@babel/helper-module-transforms': 7.27.1(@babel/core@7.27.1)
+      '@babel/helpers': 7.27.1
+      '@babel/parser': 7.27.1
+      '@babel/template': 7.27.1
+      '@babel/traverse': 7.27.1
+      '@babel/types': 7.27.1
       convert-source-map: 2.0.0
       debug: 4.4.0
       gensync: 1.0.0-beta.2
@@ -2599,35 +2657,35 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/generator@7.26.5':
+  '@babel/generator@7.27.1':
     dependencies:
-      '@babel/parser': 7.26.5
-      '@babel/types': 7.26.5
+      '@babel/parser': 7.27.1
+      '@babel/types': 7.27.1
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 3.1.0
 
-  '@babel/helper-compilation-targets@7.26.5':
+  '@babel/helper-compilation-targets@7.27.1':
     dependencies:
-      '@babel/compat-data': 7.26.5
-      '@babel/helper-validator-option': 7.25.9
+      '@babel/compat-data': 7.27.1
+      '@babel/helper-validator-option': 7.27.1
       browserslist: 4.24.4
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-module-imports@7.25.9':
+  '@babel/helper-module-imports@7.27.1':
     dependencies:
-      '@babel/traverse': 7.26.5
-      '@babel/types': 7.26.5
+      '@babel/traverse': 7.27.1
+      '@babel/types': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.26.0(@babel/core@7.26.0)':
+  '@babel/helper-module-transforms@7.27.1(@babel/core@7.27.1)':
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/helper-module-imports': 7.25.9
-      '@babel/helper-validator-identifier': 7.25.9
-      '@babel/traverse': 7.26.5
+      '@babel/core': 7.27.1
+      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/traverse': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
@@ -2635,46 +2693,54 @@ snapshots:
 
   '@babel/helper-string-parser@7.25.9': {}
 
+  '@babel/helper-string-parser@7.27.1': {}
+
   '@babel/helper-validator-identifier@7.25.9': {}
 
-  '@babel/helper-validator-option@7.25.9': {}
+  '@babel/helper-validator-identifier@7.27.1': {}
 
-  '@babel/helpers@7.26.0':
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.27.1':
     dependencies:
-      '@babel/template': 7.25.9
-      '@babel/types': 7.26.5
+      '@babel/template': 7.27.1
+      '@babel/types': 7.27.1
 
   '@babel/parser@7.26.5':
     dependencies:
       '@babel/types': 7.26.5
 
-  '@babel/plugin-transform-react-jsx-self@7.25.9(@babel/core@7.26.0)':
+  '@babel/parser@7.27.1':
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/types': 7.27.1
+
+  '@babel/plugin-transform-react-jsx-self@7.25.9(@babel/core@7.27.1)':
+    dependencies:
+      '@babel/core': 7.27.1
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-transform-react-jsx-source@7.25.9(@babel/core@7.26.0)':
+  '@babel/plugin-transform-react-jsx-source@7.25.9(@babel/core@7.27.1)':
     dependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.27.1
       '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/runtime@7.26.0':
     dependencies:
       regenerator-runtime: 0.14.1
 
-  '@babel/template@7.25.9':
+  '@babel/template@7.27.1':
     dependencies:
-      '@babel/code-frame': 7.26.2
-      '@babel/parser': 7.26.5
-      '@babel/types': 7.26.5
+      '@babel/code-frame': 7.27.1
+      '@babel/parser': 7.27.1
+      '@babel/types': 7.27.1
 
-  '@babel/traverse@7.26.5':
+  '@babel/traverse@7.27.1':
     dependencies:
-      '@babel/code-frame': 7.26.2
-      '@babel/generator': 7.26.5
-      '@babel/parser': 7.26.5
-      '@babel/template': 7.25.9
-      '@babel/types': 7.26.5
+      '@babel/code-frame': 7.27.1
+      '@babel/generator': 7.27.1
+      '@babel/parser': 7.27.1
+      '@babel/template': 7.27.1
+      '@babel/types': 7.27.1
       debug: 4.4.0
       globals: 11.12.0
     transitivePeerDependencies:
@@ -2685,18 +2751,26 @@ snapshots:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
 
+  '@babel/types@7.27.1':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
+
   '@bundled-es-modules/cookie@2.0.1':
     dependencies:
       cookie: 0.7.2
+    optional: true
 
   '@bundled-es-modules/statuses@1.0.1':
     dependencies:
       statuses: 2.0.1
+    optional: true
 
   '@bundled-es-modules/tough-cookie@0.1.6':
     dependencies:
       '@types/tough-cookie': 4.0.5
       tough-cookie: 4.1.4
+    optional: true
 
   '@emnapi/runtime@1.3.1':
     dependencies:
@@ -2852,6 +2926,7 @@ snapshots:
       '@inquirer/core': 10.1.4(@types/node@20.17.9)
       '@inquirer/type': 3.0.2(@types/node@20.17.9)
       '@types/node': 20.17.9
+    optional: true
 
   '@inquirer/core@10.1.4(@types/node@20.17.9)':
     dependencies:
@@ -2866,12 +2941,15 @@ snapshots:
       yoctocolors-cjs: 2.1.2
     transitivePeerDependencies:
       - '@types/node'
+    optional: true
 
-  '@inquirer/figures@1.0.9': {}
+  '@inquirer/figures@1.0.9':
+    optional: true
 
   '@inquirer/type@3.0.2(@types/node@20.17.9)':
     dependencies:
       '@types/node': 20.17.9
+    optional: true
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -2951,6 +3029,7 @@ snapshots:
       is-node-process: 1.2.0
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
+    optional: true
 
   '@next/env@15.1.6': {}
 
@@ -2997,14 +3076,17 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
 
-  '@open-draft/deferred-promise@2.2.0': {}
+  '@open-draft/deferred-promise@2.2.0':
+    optional: true
 
   '@open-draft/logger@0.3.0':
     dependencies:
       is-node-process: 1.2.0
       outvariant: 1.4.3
+    optional: true
 
-  '@open-draft/until@2.1.0': {}
+  '@open-draft/until@2.1.0':
+    optional: true
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -3183,7 +3265,8 @@ snapshots:
     dependencies:
       '@babel/types': 7.26.5
 
-  '@types/cookie@0.6.0': {}
+  '@types/cookie@0.6.0':
+    optional: true
 
   '@types/debug@4.1.12':
     dependencies:
@@ -3214,6 +3297,7 @@ snapshots:
   '@types/node@20.17.9':
     dependencies:
       undici-types: 6.19.8
+    optional: true
 
   '@types/react-dom@19.0.3(@types/react@19.0.8)':
     dependencies:
@@ -3223,9 +3307,11 @@ snapshots:
     dependencies:
       csstype: 3.1.3
 
-  '@types/statuses@2.0.5': {}
+  '@types/statuses@2.0.5':
+    optional: true
 
-  '@types/tough-cookie@4.0.5': {}
+  '@types/tough-cookie@4.0.5':
+    optional: true
 
   '@types/unist@2.0.11': {}
 
@@ -3233,82 +3319,80 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@vercel/analytics@1.4.1(next@15.1.6(@babel/core@7.26.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)':
+  '@vercel/analytics@1.4.1(next@15.1.6(@babel/core@7.27.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)':
     optionalDependencies:
-      next: 15.1.6(@babel/core@7.26.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      next: 15.1.6(@babel/core@7.27.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
 
-  '@vitejs/plugin-react@4.3.4(vite@5.4.11(@types/node@20.17.9)(lightningcss@1.29.1))':
+  '@vitejs/plugin-react@4.4.1(vite@5.4.11(@types/node@20.17.9)(lightningcss@1.29.1))':
     dependencies:
-      '@babel/core': 7.26.0
-      '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.0)
-      '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.0)
+      '@babel/core': 7.27.1
+      '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.27.1)
+      '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.27.1)
       '@types/babel__core': 7.20.5
-      react-refresh: 0.14.2
+      react-refresh: 0.17.0
       vite: 5.4.11(@types/node@20.17.9)(lightningcss@1.29.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/browser@3.0.5(@types/node@20.17.9)(playwright@1.50.1)(typescript@5.7.3)(vite@5.4.11(@types/node@20.17.9)(lightningcss@1.29.1))(vitest@3.0.5)':
+  '@vitest/browser@3.1.2(msw@2.7.0(@types/node@20.17.9)(typescript@5.8.3))(playwright@1.52.0)(vite@5.4.11(@types/node@20.17.9)(lightningcss@1.29.1))(vitest@3.1.2)':
     dependencies:
       '@testing-library/dom': 10.4.0
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
-      '@vitest/mocker': 3.0.5(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.3))(vite@5.4.11(@types/node@20.17.9)(lightningcss@1.29.1))
-      '@vitest/utils': 3.0.5
+      '@vitest/mocker': 3.1.2(msw@2.7.0(@types/node@20.17.9)(typescript@5.8.3))(vite@5.4.11(@types/node@20.17.9)(lightningcss@1.29.1))
+      '@vitest/utils': 3.1.2
       magic-string: 0.30.17
-      msw: 2.7.0(@types/node@20.17.9)(typescript@5.7.3)
-      sirv: 3.0.0
+      sirv: 3.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.0.5(@types/debug@4.1.12)(@types/node@20.17.9)(@vitest/browser@3.0.5)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.3))
-      ws: 8.18.0
+      vitest: 3.1.2(@types/debug@4.1.12)(@types/node@20.17.9)(@vitest/browser@3.1.2)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.8.3))
+      ws: 8.18.1
     optionalDependencies:
-      playwright: 1.50.1
+      playwright: 1.52.0
     transitivePeerDependencies:
-      - '@types/node'
       - bufferutil
-      - typescript
+      - msw
       - utf-8-validate
       - vite
 
-  '@vitest/expect@3.0.5':
+  '@vitest/expect@3.1.2':
     dependencies:
-      '@vitest/spy': 3.0.5
-      '@vitest/utils': 3.0.5
-      chai: 5.1.2
+      '@vitest/spy': 3.1.2
+      '@vitest/utils': 3.1.2
+      chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.5(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.3))(vite@5.4.11(@types/node@20.17.9)(lightningcss@1.29.1))':
+  '@vitest/mocker@3.1.2(msw@2.7.0(@types/node@20.17.9)(typescript@5.8.3))(vite@5.4.11(@types/node@20.17.9)(lightningcss@1.29.1))':
     dependencies:
-      '@vitest/spy': 3.0.5
+      '@vitest/spy': 3.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      msw: 2.7.0(@types/node@20.17.9)(typescript@5.7.3)
+      msw: 2.7.0(@types/node@20.17.9)(typescript@5.8.3)
       vite: 5.4.11(@types/node@20.17.9)(lightningcss@1.29.1)
 
-  '@vitest/pretty-format@3.0.5':
+  '@vitest/pretty-format@3.1.2':
     dependencies:
       tinyrainbow: 2.0.0
 
-  '@vitest/runner@3.0.5':
+  '@vitest/runner@3.1.2':
     dependencies:
-      '@vitest/utils': 3.0.5
-      pathe: 2.0.2
+      '@vitest/utils': 3.1.2
+      pathe: 2.0.3
 
-  '@vitest/snapshot@3.0.5':
+  '@vitest/snapshot@3.1.2':
     dependencies:
-      '@vitest/pretty-format': 3.0.5
+      '@vitest/pretty-format': 3.1.2
       magic-string: 0.30.17
-      pathe: 2.0.2
+      pathe: 2.0.3
 
-  '@vitest/spy@3.0.5':
+  '@vitest/spy@3.1.2':
     dependencies:
       tinyspy: 3.0.2
 
-  '@vitest/utils@3.0.5':
+  '@vitest/utils@3.1.2':
     dependencies:
-      '@vitest/pretty-format': 3.0.5
-      loupe: 3.1.2
+      '@vitest/pretty-format': 3.1.2
+      loupe: 3.1.3
       tinyrainbow: 2.0.0
 
   acorn-jsx@5.3.2(acorn@8.14.0):
@@ -3320,6 +3404,7 @@ snapshots:
   ansi-escapes@4.3.2:
     dependencies:
       type-fest: 0.21.3
+    optional: true
 
   ansi-regex@5.0.1: {}
 
@@ -3395,7 +3480,7 @@ snapshots:
 
   ccount@2.0.1: {}
 
-  chai@5.1.2:
+  chai@5.2.0:
     dependencies:
       assertion-error: 2.0.1
       check-error: 2.1.1
@@ -3430,7 +3515,8 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  cli-width@4.1.0: {}
+  cli-width@4.1.0:
+    optional: true
 
   client-only@0.0.1: {}
 
@@ -3439,6 +3525,7 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+    optional: true
 
   code-block-writer@13.0.3: {}
 
@@ -3477,7 +3564,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  cookie@0.7.2: {}
+  cookie@0.7.2:
+    optional: true
 
   cross-spawn@7.0.6:
     dependencies:
@@ -3624,7 +3712,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.6
 
-  expect-type@1.1.0: {}
+  expect-type@1.2.1: {}
 
   extend@3.0.2: {}
 
@@ -3643,6 +3731,10 @@ snapshots:
   fault@2.0.1:
     dependencies:
       format: 0.2.2
+
+  fdir@6.4.4(picomatch@4.0.2):
+    optionalDependencies:
+      picomatch: 4.0.2
 
   fill-range@7.1.1:
     dependencies:
@@ -3667,7 +3759,8 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
-  get-caller-file@2.0.5: {}
+  get-caller-file@2.0.5:
+    optional: true
 
   glob-parent@5.1.2:
     dependencies:
@@ -3693,7 +3786,8 @@ snapshots:
 
   globals@11.12.0: {}
 
-  graphql@16.10.0: {}
+  graphql@16.10.0:
+    optional: true
 
   gunning-fog@1.0.6: {}
 
@@ -3811,7 +3905,8 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
-  headers-polyfill@4.0.3: {}
+  headers-polyfill@4.0.3:
+    optional: true
 
   html-void-elements@3.0.0: {}
 
@@ -3857,7 +3952,8 @@ snapshots:
 
   is-hexadecimal@2.0.1: {}
 
-  is-node-process@1.2.0: {}
+  is-node-process@1.2.0:
+    optional: true
 
   is-number@7.0.0: {}
 
@@ -3940,6 +4036,8 @@ snapshots:
   longest-streak@3.1.0: {}
 
   loupe@3.1.2: {}
+
+  loupe@3.1.3: {}
 
   lru-cache@10.4.3: {}
 
@@ -4440,7 +4538,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.7.0(@types/node@20.17.9)(typescript@5.7.3):
+  msw@2.7.0(@types/node@20.17.9)(typescript@5.8.3):
     dependencies:
       '@bundled-es-modules/cookie': 2.0.1
       '@bundled-es-modules/statuses': 1.0.1
@@ -4461,11 +4559,13 @@ snapshots:
       type-fest: 4.32.0
       yargs: 17.7.2
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 5.8.3
     transitivePeerDependencies:
       - '@types/node'
+    optional: true
 
-  mute-stream@2.0.0: {}
+  mute-stream@2.0.0:
+    optional: true
 
   mz@2.7.0:
     dependencies:
@@ -4475,7 +4575,7 @@ snapshots:
 
   nanoid@3.3.8: {}
 
-  next@15.1.6(@babel/core@7.26.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+  next@15.1.6(@babel/core@7.27.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       '@next/env': 15.1.6
       '@swc/counter': 0.1.3
@@ -4485,7 +4585,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-      styled-jsx: 5.1.6(@babel/core@7.26.0)(react@19.0.0)
+      styled-jsx: 5.1.6(@babel/core@7.27.1)(react@19.0.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.1.6
       '@next/swc-darwin-x64': 15.1.6
@@ -4530,7 +4630,8 @@ snapshots:
       regex: 5.1.1
       regex-recursion: 5.1.1
 
-  outvariant@1.4.3: {}
+  outvariant@1.4.3:
+    optional: true
 
   package-json-from-dist@1.0.1: {}
 
@@ -4578,9 +4679,10 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.2
 
-  path-to-regexp@6.3.0: {}
+  path-to-regexp@6.3.0:
+    optional: true
 
-  pathe@2.0.2: {}
+  pathe@2.0.3: {}
 
   pathval@2.0.0: {}
 
@@ -4588,15 +4690,17 @@ snapshots:
 
   picomatch@2.3.1: {}
 
+  picomatch@4.0.2: {}
+
   pify@2.3.0: {}
 
   pirates@4.0.6: {}
 
-  playwright-core@1.50.1: {}
+  playwright-core@1.52.0: {}
 
-  playwright@1.50.1:
+  playwright@1.52.0:
     dependencies:
-      playwright-core: 1.50.1
+      playwright-core: 1.52.0
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -4650,7 +4754,7 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  prettier@3.4.2: {}
+  prettier@3.5.3: {}
 
   pretty-format@27.5.1:
     dependencies:
@@ -4665,10 +4769,13 @@ snapshots:
   psl@1.15.0:
     dependencies:
       punycode: 2.3.1
+    optional: true
 
-  punycode@2.3.1: {}
+  punycode@2.3.1:
+    optional: true
 
-  querystringify@2.2.0: {}
+  querystringify@2.2.0:
+    optional: true
 
   queue-microtask@1.2.3: {}
 
@@ -4679,7 +4786,7 @@ snapshots:
 
   react-is@17.0.2: {}
 
-  react-refresh@0.14.2: {}
+  react-refresh@0.17.0: {}
 
   react@19.0.0: {}
 
@@ -4882,9 +4989,11 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  require-directory@2.1.1: {}
+  require-directory@2.1.1:
+    optional: true
 
-  requires-port@1.0.0: {}
+  requires-port@1.0.0:
+    optional: true
 
   resolve@1.22.10:
     dependencies:
@@ -5016,7 +5125,7 @@ snapshots:
       is-arrayish: 0.3.2
     optional: true
 
-  sirv@3.0.0:
+  sirv@3.0.1:
     dependencies:
       '@polka/url': 1.0.0-next.28
       mrmime: 2.0.0
@@ -5036,15 +5145,17 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  statuses@2.0.1: {}
+  statuses@2.0.1:
+    optional: true
 
-  std-env@3.8.0: {}
+  std-env@3.9.0: {}
 
   stemmer@1.0.5: {}
 
   streamsearch@1.1.0: {}
 
-  strict-event-emitter@0.5.1: {}
+  strict-event-emitter@0.5.1:
+    optional: true
 
   string-width@4.2.3:
     dependencies:
@@ -5079,12 +5190,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.4
 
-  styled-jsx@5.1.6(@babel/core@7.26.0)(react@19.0.0):
+  styled-jsx@5.1.6(@babel/core@7.27.1)(react@19.0.0):
     dependencies:
       client-only: 0.0.1
       react: 19.0.0
     optionalDependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 7.27.1
 
   sucrase@3.35.0:
     dependencies:
@@ -5146,6 +5257,11 @@ snapshots:
 
   tinyexec@0.3.2: {}
 
+  tinyglobby@0.2.13:
+    dependencies:
+      fdir: 6.4.4(picomatch@4.0.2)
+      picomatch: 4.0.2
+
   tinypool@1.0.2: {}
 
   tinyrainbow@2.0.0: {}
@@ -5170,6 +5286,7 @@ snapshots:
       punycode: 2.3.1
       universalify: 0.2.0
       url-parse: 1.5.10
+    optional: true
 
   trim-lines@3.0.1: {}
 
@@ -5186,15 +5303,18 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  type-fest@0.21.3: {}
+  type-fest@0.21.3:
+    optional: true
 
-  type-fest@4.32.0: {}
+  type-fest@4.32.0:
+    optional: true
 
   typescript@5.7.2: {}
 
-  typescript@5.7.3: {}
+  typescript@5.8.3: {}
 
-  undici-types@6.19.8: {}
+  undici-types@6.19.8:
+    optional: true
 
   unherit@1.1.3:
     dependencies:
@@ -5285,7 +5405,8 @@ snapshots:
       unist-util-is: 6.0.0
       unist-util-visit-parents: 6.0.1
 
-  universalify@0.2.0: {}
+  universalify@0.2.0:
+    optional: true
 
   update-browserslist-db@1.1.2(browserslist@4.24.4):
     dependencies:
@@ -5297,6 +5418,7 @@ snapshots:
     dependencies:
       querystringify: 2.2.0
       requires-port: 1.0.0
+    optional: true
 
   util-deprecate@1.0.2: {}
 
@@ -5332,12 +5454,12 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-node@3.0.5(@types/node@20.17.9)(lightningcss@1.29.1):
+  vite-node@3.1.2(@types/node@20.17.9)(lightningcss@1.29.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.6.0
-      pathe: 2.0.2
+      pathe: 2.0.3
       vite: 5.4.11(@types/node@20.17.9)(lightningcss@1.29.1)
     transitivePeerDependencies:
       - '@types/node'
@@ -5360,42 +5482,43 @@ snapshots:
       fsevents: 2.3.3
       lightningcss: 1.29.1
 
-  vitest-browser-react@0.0.4(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(@vitest/browser@3.0.5(@types/node@20.17.9)(playwright@1.50.1)(typescript@5.7.3)(vite@5.4.11(@types/node@20.17.9)(lightningcss@1.29.1))(vitest@3.0.5))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(vitest@3.0.5(@types/debug@4.1.12)(@types/node@20.17.9)(@vitest/browser@3.0.5)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.3))):
+  vitest-browser-react@0.1.1(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(@vitest/browser@3.1.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(vitest@3.1.2):
     dependencies:
-      '@vitest/browser': 3.0.5(@types/node@20.17.9)(playwright@1.50.1)(typescript@5.7.3)(vite@5.4.11(@types/node@20.17.9)(lightningcss@1.29.1))(vitest@3.0.5)
+      '@vitest/browser': 3.1.2(msw@2.7.0(@types/node@20.17.9)(typescript@5.8.3))(playwright@1.52.0)(vite@5.4.11(@types/node@20.17.9)(lightningcss@1.29.1))(vitest@3.1.2)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-      vitest: 3.0.5(@types/debug@4.1.12)(@types/node@20.17.9)(@vitest/browser@3.0.5)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.3))
+      vitest: 3.1.2(@types/debug@4.1.12)(@types/node@20.17.9)(@vitest/browser@3.1.2)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.8.3))
     optionalDependencies:
       '@types/react': 19.0.8
       '@types/react-dom': 19.0.3(@types/react@19.0.8)
 
-  vitest@3.0.5(@types/debug@4.1.12)(@types/node@20.17.9)(@vitest/browser@3.0.5)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.3)):
+  vitest@3.1.2(@types/debug@4.1.12)(@types/node@20.17.9)(@vitest/browser@3.1.2)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.17.9)(typescript@5.8.3)):
     dependencies:
-      '@vitest/expect': 3.0.5
-      '@vitest/mocker': 3.0.5(msw@2.7.0(@types/node@20.17.9)(typescript@5.7.3))(vite@5.4.11(@types/node@20.17.9)(lightningcss@1.29.1))
-      '@vitest/pretty-format': 3.0.5
-      '@vitest/runner': 3.0.5
-      '@vitest/snapshot': 3.0.5
-      '@vitest/spy': 3.0.5
-      '@vitest/utils': 3.0.5
-      chai: 5.1.2
+      '@vitest/expect': 3.1.2
+      '@vitest/mocker': 3.1.2(msw@2.7.0(@types/node@20.17.9)(typescript@5.8.3))(vite@5.4.11(@types/node@20.17.9)(lightningcss@1.29.1))
+      '@vitest/pretty-format': 3.1.2
+      '@vitest/runner': 3.1.2
+      '@vitest/snapshot': 3.1.2
+      '@vitest/spy': 3.1.2
+      '@vitest/utils': 3.1.2
+      chai: 5.2.0
       debug: 4.4.0
-      expect-type: 1.1.0
+      expect-type: 1.2.1
       magic-string: 0.30.17
-      pathe: 2.0.2
-      std-env: 3.8.0
+      pathe: 2.0.3
+      std-env: 3.9.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
+      tinyglobby: 0.2.13
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
       vite: 5.4.11(@types/node@20.17.9)(lightningcss@1.29.1)
-      vite-node: 3.0.5(@types/node@20.17.9)(lightningcss@1.29.1)
+      vite-node: 3.1.2(@types/node@20.17.9)(lightningcss@1.29.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 20.17.9
-      '@vitest/browser': 3.0.5(@types/node@20.17.9)(playwright@1.50.1)(typescript@5.7.3)(vite@5.4.11(@types/node@20.17.9)(lightningcss@1.29.1))(vitest@3.0.5)
+      '@vitest/browser': 3.1.2(msw@2.7.0(@types/node@20.17.9)(typescript@5.8.3))(playwright@1.52.0)(vite@5.4.11(@types/node@20.17.9)(lightningcss@1.29.1))(vitest@3.1.2)
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -5421,6 +5544,7 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+    optional: true
 
   wrap-ansi@7.0.0:
     dependencies:
@@ -5436,15 +5560,19 @@ snapshots:
 
   ws@8.18.0: {}
 
+  ws@8.18.1: {}
+
   xtend@4.0.2: {}
 
-  y18n@5.0.8: {}
+  y18n@5.0.8:
+    optional: true
 
   yallist@3.1.1: {}
 
   yaml@2.6.1: {}
 
-  yargs-parser@21.1.1: {}
+  yargs-parser@21.1.1:
+    optional: true
 
   yargs@17.7.2:
     dependencies:
@@ -5455,7 +5583,9 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+    optional: true
 
-  yoctocolors-cjs@2.1.2: {}
+  yoctocolors-cjs@2.1.2:
+    optional: true
 
   zwitch@2.0.4: {}

--- a/src/client-styles.tsx
+++ b/src/client-styles.tsx
@@ -2,6 +2,7 @@
 import { useLayoutEffect } from 'react'
 
 import type { CSSRule } from './types.js'
+import { addToRulesCache } from './create-rules.js'
 
 let hasRenderedInitialStylesToDepth = -1
 type NestedRules = [CSSRule[], CSSRule[], CSSRule[], NestedRules[]]
@@ -27,6 +28,9 @@ export function ClientStyles({
   d?: number
 }) {
   const [lowRules, mediumRules, highRules, nested] = rules
+  for (const rule of [...lowRules, ...mediumRules, ...highRules]) {
+    addToRulesCache(rule[0], rule[2])
+  }
 
   /* Only render the initial styles for each depth once to establish precedence order */
   const hasRenderedThisDepth = hasRenderedInitialStylesToDepth >= depth

--- a/src/create-rules.test.ts
+++ b/src/create-rules.test.ts
@@ -15,6 +15,9 @@ describe('createRules', () => {
             [
               "hh45au7",
               ".hh45au7{color:red}",
+              {
+                "color": "red",
+              },
             ],
           ],
           [],
@@ -26,28 +29,31 @@ describe('createRules', () => {
   it('handles parent selectors', () => {
     const result = createRules({ '[data-theme]& span': { color: 'red' } })
     expect(result).toMatchInlineSnapshot(`
+    [
+      "h9ymzgp",
       [
-        "h9ymzgp",
+        [],
+        [],
+        [],
         [
-          [],
-          [],
-          [],
           [
+            [],
+            [],
             [
-              [],
-              [],
               [
-                [
-                  "h9ymzgp",
-                  "[data-theme].h9ymzgp span{color:red}",
-                ],
+                "h9ymzgp",
+                "[data-theme].h9ymzgp span{color:red}",
+                {
+                  "color": "red",
+                },
               ],
-              [],
             ],
+            [],
           ],
         ],
-      ]
-    `)
+      ],
+    ]
+  `)
   })
 
   it('handles nested rules', () => {
@@ -68,24 +74,8 @@ describe('createRules', () => {
       },
     })
     expect(result).toMatchInlineSnapshot(`
-      [
-        "ho9xm10 ho9xm10 h1vtbor2 h1qhiauq",
-        [
-          [],
-          [],
-          [],
           [
-            [
-              [],
-              [],
-              [
-                [
-                  "ho9xm10",
-                  ".ho9xm10 h1::before{content:""}",
-                ],
-              ],
-              [],
-            ],
+            "ho9xm10 ho9xm10 h1vtbor2 h1qhiauq",
             [
               [],
               [],
@@ -98,39 +88,73 @@ describe('createRules', () => {
                     [
                       "ho9xm10",
                       ".ho9xm10 h1::before{content:""}",
+                      {
+                        "content": """",
+                      },
                     ],
                   ],
                   [],
                 ],
-              ],
-            ],
-            [
-              [],
-              [],
-              [
                 [
-                  "h1vtbor2",
-                  "@media (width >= 768px){.h1vtbor2{color:green}}",
+                  [],
+                  [],
+                  [],
+                  [
+                    [
+                      [],
+                      [],
+                      [
+                        [
+                          "ho9xm10",
+                          ".ho9xm10 h1::before{content:""}",
+                          {
+                            "content": """",
+                          },
+                        ],
+                      ],
+                      [],
+                    ],
+                  ],
                 ],
-              ],
-              [
                 [
                   [],
                   [],
                   [
                     [
-                      "h1qhiauq",
-                      "@media (width >= 768px){@media (width <= 1024px){.h1qhiauq{color:orange}}}",
+                      "h1vtbor2",
+                      "@media (width >= 768px){.h1vtbor2{color:green}}",
+                      {
+                        "@media (width >= 768px)": {
+                          "color": "green",
+                        },
+                      },
                     ],
                   ],
-                  [],
+                  [
+                    [
+                      [],
+                      [],
+                      [
+                        [
+                          "h1qhiauq",
+                          "@media (width >= 768px){@media (width <= 1024px){.h1qhiauq{color:orange}}}",
+                          {
+                            "@media (width >= 768px)": {
+                              "@media (width <= 1024px)": {
+                                "color": "orange",
+                              },
+                            },
+                          },
+                        ],
+                      ],
+                      [],
+                    ],
+                  ],
                 ],
               ],
             ],
-          ],
-        ],
-      ]
-    `)
+          ]
+        `)
   })
 
   it('merges CSS objects', () => {

--- a/src/create-rules.test.ts
+++ b/src/create-rules.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 
-import { createRules } from './create-rules.js'
+import { createRules, mergeStyles } from './create-rules.js'
 
 describe('createRules', () => {
   it('should convert simple style object into CSS rules', () => {
@@ -131,5 +131,25 @@ describe('createRules', () => {
         ],
       ]
     `)
+  })
+
+  it('merges CSS objects', () => {
+    const result = mergeStyles([
+      {
+        color: 'red',
+        nested: { color: 'green', background: 'orange' },
+        one: 2,
+      },
+      { color: 'blue', nested: { color: 'yellow' } },
+    ])
+
+    expect(result).toEqual({
+      color: 'blue',
+      nested: {
+        color: 'yellow',
+        background: 'orange',
+      },
+      one: 2,
+    })
   })
 })

--- a/src/create-rules.ts
+++ b/src/create-rules.ts
@@ -8,6 +8,9 @@ import { resolveNestedSelector, l, m, u, hash } from './utils.js'
 
 /** map every generated className back to its original CSS object */
 const rulesCache: Record<string, CSSObject> = {}
+export const addToRulesCache = (className: string, cssObject: CSSObject) => {
+  rulesCache[className] = cssObject
+}
 
 /** type checking for objects */
 const isNestedObject = (
@@ -154,7 +157,7 @@ export function createRules(
     const precedence = l.has(key) ? 'l' : m.has(key) ? 'm' : 'h'
     const className =
       precedence + hash(key + value + selector + atRules.join(''))
-    rulesCache[className] = originalObject
+    addToRulesCache(className, originalObject)
     let rule = createRule(className, selector, key, value)
     if (atRules.length > 0) {
       const atPrefix = atRules.join('{') + '{'
@@ -163,11 +166,11 @@ export function createRules(
     }
     classNames += className + ' '
     if (precedence === 'l') {
-      lowRules.push([className, rule])
+      lowRules.push([className, rule, originalObject])
     } else if (precedence === 'm') {
-      mediumRules.push([className, rule])
+      mediumRules.push([className, rule, originalObject])
     } else {
-      highRules.push([className, rule])
+      highRules.push([className, rule, originalObject])
     }
   }
 

--- a/src/css.tsx
+++ b/src/css.tsx
@@ -10,9 +10,10 @@ import type { CSSObject } from './types.js'
  */
 export function css(
   styles: CSSObject,
-  nonce?: string
+  nonce?: string,
+  classOverrides?: string[]
 ): [string, () => React.JSX.Element] {
-  const [classNames, rules] = createRules(styles)
+  const [classNames, rules] = createRules(styles, '', [], classOverrides)
 
   function Styles() {
     return <ClientStyles r={rules} n={nonce} />

--- a/src/styled.tsx
+++ b/src/styled.tsx
@@ -76,10 +76,14 @@ export function styled(
       parsedStyles = styles || {}
     }
 
-    const [classNames, Styles] = css({
-      ...parsedStyles,
-      ...cssProp,
-    })
+    const [classNames, Styles] = css(
+      {
+        ...parsedStyles,
+        ...cssProp,
+      },
+      undefined,
+      classNameProp?.split(' ').map((x) => x.trim())
+    )
     const className = classNameProp
       ? classNameProp + ' ' + classNames
       : classNames

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,11 @@ export type CSSObject = React.CSSProperties & {
 
 export type CSSValue = CSSObject[keyof CSSObject]
 
-export type CSSRule = [className: string, rule?: string]
+export type CSSRule = [
+  className: string,
+  rule: string,
+  originalObject: CSSObject,
+]
 
 export type CSSRulePrecedences = [
   CSSRule[],

--- a/test/composition.test.tsx
+++ b/test/composition.test.tsx
@@ -1,0 +1,306 @@
+import { describe, it } from 'vitest'
+import { render } from 'vitest-browser-react'
+import { styled } from '../src/styled.js'
+import { expectMatchingStyles } from './expectMatchingStyles.js'
+import { page } from '@vitest/browser/context'
+
+describe('composition', () => {
+  it('overrides classes in the simplest case', () => {
+    // we'll render just our colors first to establish their priority
+    const Red = styled('div', {
+      color: 'red',
+    })
+    const Green = styled('div', {
+      color: 'green',
+    })
+
+    const Test = styled(Red, {
+      color: 'green',
+    })
+
+    const screen = render(
+      <div>
+        <Red />
+        <Green />
+        <Test />
+      </div>
+    )
+
+    expectMatchingStyles(
+      screen,
+      <div>
+        <div id="red"></div>
+        <div id="green"></div>
+        <div id="test"></div>
+      </div>,
+      (css) => css`
+        #red {
+          color: red;
+        }
+        #green {
+          color: green;
+        }
+        #test {
+          color: green;
+        }
+      `
+    )
+  })
+
+  it('overrides classes in a longer chain', () => {
+    const Red = styled('div', {
+      color: 'red',
+    })
+    const Green = styled('div', {
+      color: 'green',
+    })
+    const Blue = styled('div', {
+      color: 'blue',
+    })
+
+    const FirstChain = styled(Red, {
+      color: 'green',
+    })
+    const SecondChain = styled(FirstChain, {
+      color: 'blue',
+    })
+
+    const screen = render(
+      <div>
+        <Red />
+        <Green />
+        <Blue />
+        <FirstChain />
+        <SecondChain />
+      </div>
+    )
+
+    expectMatchingStyles(
+      screen,
+      <div>
+        <div id="r"></div>
+        <div id="g"></div>
+        <div id="b"></div>
+        <div id="first"></div>
+        <div id="second"></div>
+      </div>,
+      (css) => css`
+        #r {
+          color: red;
+        }
+        #g {
+          color: green;
+        }
+        #b {
+          color: blue;
+        }
+        #first {
+          color: green;
+        }
+        #second {
+          color: blue;
+        }
+      `
+    )
+  })
+
+  it('overrides classes when nested', async () => {
+    const A = styled('div', {
+      color: 'red',
+      '@media (width < 1000px)': {
+        color: 'blue',
+      },
+    })
+    const B = styled(A, {
+      color: 'green',
+    })
+
+    const screen = render(
+      <div>
+        <A />
+        <B />
+      </div>
+    )
+
+    // both should be blue when viewport is <= 1000px
+    expectMatchingStyles(
+      screen,
+      <div>
+        <div id="a"></div>
+        <div id="b"></div>
+      </div>,
+      (css) => css`
+        #a,
+        #b {
+          color: blue;
+        }
+      `
+    )
+
+    await page.viewport(1000, 1000)
+    expectMatchingStyles(
+      screen,
+      <div>
+        <div id="a"></div>
+        <div id="b"></div>
+      </div>,
+      (css) => css`
+        #a {
+          color: red;
+        }
+        #b {
+          color: green;
+        }
+      `
+    )
+  })
+
+  it('overrides classes when nested deeply', () => {
+    const A = styled('div', {
+      color: 'red',
+      '@media (width <= 1000px)': {
+        color: 'orange',
+        '&:first-child': {
+          color: 'blue',
+        },
+      },
+    })
+
+    const B = styled(A, {
+      color: 'green',
+    })
+
+    // first child should be blue when viewport is <= 1000px
+    // second child should be orange when viewport is <= 1000px
+    expectMatchingStyles(
+      render(
+        <div>
+          <B />
+          <B />
+          <A />
+        </div>
+      ),
+      <div>
+        <div id="b"></div>
+        <div id="b"></div>
+        <div id="a"></div>
+      </div>,
+      (css) => css`
+        #a {
+          color: red;
+          @media (width <= 1000px) {
+            color: orange;
+            &:first-child {
+              color: blue;
+            }
+          }
+        }
+        #b {
+          color: green;
+          @media (width <= 1000px) {
+            color: orange;
+            &:first-child {
+              color: blue;
+            }
+          }
+        }
+      `
+    )
+  })
+
+  it('overrides classes through a component in the middle', () => {
+    const A = styled('div', {
+      color: 'red',
+    })
+
+    const SomeComponent = ({ className }: { className?: string }) => (
+      <A className={className} />
+    )
+
+    const B = styled(SomeComponent, {
+      color: 'green',
+    })
+
+    // B should always be green, regardless of order
+    expectMatchingStyles(
+      render(
+        <div>
+          <A />
+          <B />
+        </div>
+      ),
+      <div>
+        <div id="a"></div>
+        <div id="b"></div>
+      </div>,
+      (css) => css`
+        #a {
+          color: red;
+        }
+        #b {
+          color: green;
+        }
+      `
+    )
+
+    expectMatchingStyles(
+      render(
+        <div>
+          <B />
+          <A />
+        </div>
+      ),
+      <div>
+        <div id="b"></div>
+        <div id="a"></div>
+      </div>,
+      (css) => css`
+        #a {
+          color: red;
+        }
+        #b {
+          color: green;
+        }
+      `
+    )
+  })
+
+  it('respects the css prop', () => {
+    const A = styled('div', {
+      color: 'red',
+    })
+
+    const B = styled(A, {
+      color: 'green',
+    })
+
+    // css prop is always highest priority
+    expectMatchingStyles(
+      render(
+        <div>
+          <B />
+          <A />
+          <B css={{ color: 'blue' }} />
+          <A css={{ color: 'blue' }} />
+        </div>
+      ),
+      <div>
+        <div id="b"></div>
+        <div id="a"></div>
+        <div className="blue"></div>
+        <div className="blue"></div>
+      </div>,
+      (css) => css`
+        #a {
+          color: red;
+        }
+        #b {
+          color: green;
+        }
+        .blue {
+          color: blue;
+        }
+      `
+    )
+  })
+})

--- a/test/expectMatchingStyles.test.tsx
+++ b/test/expectMatchingStyles.test.tsx
@@ -1,0 +1,96 @@
+import { test } from 'vitest'
+import { render } from 'vitest-browser-react'
+import { expectMatchingStyles } from './expectMatchingStyles.js'
+import { styled } from '../src/styled.js'
+import { page } from '@vitest/browser/context'
+
+// basic matching test
+test('expectMatchingStyles', () => {
+  const screen = render(<div>hello world</div>)
+
+  expectMatchingStyles(
+    screen,
+    (html) => html` <div>hello world</div> `,
+    (css) => css``
+  )
+})
+
+const Text = styled('div', ({ color }: { color?: string }) => ({
+  color: color || 'red',
+}))
+
+// components with styles
+test('expectMatchingStyles - styled', () => {
+  const screen = render(<Text>hello world</Text>)
+
+  expectMatchingStyles(
+    screen,
+    (html) => html` <div>hello world</div> `,
+    (css) => css`
+      div {
+        color: red;
+      }
+    `
+  )
+})
+
+// checking components after rerender
+test('expectMatchingStyles - rerender', () => {
+  const screen = render(<Text>hello world</Text>)
+
+  expectMatchingStyles(
+    screen,
+    (html) => html` <div>hello world</div> `,
+    (css) => css`
+      div {
+        color: red;
+      }
+    `
+  )
+
+  screen.rerender(<Text color="blue">hello world</Text>)
+
+  expectMatchingStyles(
+    screen,
+    (html) => html` <div>hello world</div> `,
+    (css) => css`
+      div {
+        color: blue;
+      }
+    `
+  )
+})
+
+const MediaTest = styled('div', {
+  color: 'red',
+  '@media (width >= 1000px)': {
+    color: 'blue',
+  },
+})
+
+// different viewport sizes
+test('expectMatchingStyles - viewport sizes', async () => {
+  const screen = render(<MediaTest>hello world</MediaTest>)
+
+  expectMatchingStyles(
+    screen,
+    (html) => html` <div>hello world</div> `,
+    (css) => css`
+      div {
+        color: red;
+      }
+    `
+  )
+
+  await page.viewport(1000, 1000)
+
+  expectMatchingStyles(
+    screen,
+    (html) => html` <div>hello world</div> `,
+    (css) => css`
+      div {
+        color: blue;
+      }
+    `
+  )
+})

--- a/test/expectMatchingStyles.test.tsx
+++ b/test/expectMatchingStyles.test.tsx
@@ -8,11 +8,7 @@ import { page } from '@vitest/browser/context'
 test('expectMatchingStyles', () => {
   const screen = render(<div>hello world</div>)
 
-  expectMatchingStyles(
-    screen,
-    (html) => html` <div>hello world</div> `,
-    (css) => css``
-  )
+  expectMatchingStyles(screen, <div>hello world</div>, (css) => css``)
 })
 
 const Text = styled('div', ({ color }: { color?: string }) => ({
@@ -25,7 +21,7 @@ test('expectMatchingStyles - styled', () => {
 
   expectMatchingStyles(
     screen,
-    (html) => html` <div>hello world</div> `,
+    <div>hello world</div>,
     (css) => css`
       div {
         color: red;
@@ -40,7 +36,7 @@ test('expectMatchingStyles - rerender', () => {
 
   expectMatchingStyles(
     screen,
-    (html) => html` <div>hello world</div> `,
+    <div>hello world</div>,
     (css) => css`
       div {
         color: red;
@@ -52,7 +48,7 @@ test('expectMatchingStyles - rerender', () => {
 
   expectMatchingStyles(
     screen,
-    (html) => html` <div>hello world</div> `,
+    <div>hello world</div>,
     (css) => css`
       div {
         color: blue;
@@ -74,7 +70,7 @@ test('expectMatchingStyles - viewport sizes', async () => {
 
   expectMatchingStyles(
     screen,
-    (html) => html` <div>hello world</div> `,
+    <div>hello world</div>,
     (css) => css`
       div {
         color: red;
@@ -86,7 +82,7 @@ test('expectMatchingStyles - viewport sizes', async () => {
 
   expectMatchingStyles(
     screen,
-    (html) => html` <div>hello world</div> `,
+    <div>hello world</div>,
     (css) => css`
       div {
         color: blue;

--- a/test/expectMatchingStyles.tsx
+++ b/test/expectMatchingStyles.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
 import { expect } from 'vitest'
 import type { RenderResult } from 'vitest-browser-react'
 
@@ -55,10 +57,10 @@ const expectElementMatches = (
 
 export const expectMatchingStyles = (
   screen: RenderResult,
-  html: (html: typeof String.raw) => string,
+  html: ReactNode,
   css: (css: typeof String.raw) => string
 ) => {
-  const htmlInput = html(String.raw) ?? ''
+  const htmlInput = renderToStaticMarkup(html)
   const cssInput = css(String.raw) ?? ''
 
   // open a new tab

--- a/test/expectMatchingStyles.tsx
+++ b/test/expectMatchingStyles.tsx
@@ -1,0 +1,98 @@
+import { expect } from 'vitest'
+import type { RenderResult } from 'vitest-browser-react'
+
+/**
+ * in order to deeply compare styles across all browsers, we need to convert
+ * to a regular object - deep comparison of style objects will always
+ * succeed in webkit & firefox otherwise
+ */
+const styleDeclarationToObject = (style: CSSStyleDeclaration) => {
+  const object: Record<string, string | undefined> = {}
+  for (const key in style) {
+    object[key] = style[key]
+  }
+  return object
+}
+
+/**
+ * recursively compare the dom structure and styles of two elements
+ * this will verify that each element has the same children and styles
+ *
+ * attributes are not compared
+ *
+ * @param elementA
+ * @param elementB
+ * @returns
+ */
+const expectElementMatches = (
+  elementA: Element | undefined,
+  elementB: Element | undefined
+) => {
+  if (elementA === undefined || elementB === undefined) return
+
+  const elementStyleA = styleDeclarationToObject(
+    window.getComputedStyle(elementA)
+  )
+  const elementStyleB = styleDeclarationToObject(
+    window.getComputedStyle(elementB)
+  )
+
+  // verify that the dom structure matches
+  expect(elementA.tagName).toEqual(elementB.tagName)
+  expect(elementA.children.length).toEqual(elementB.children.length)
+
+  // verify that styles match
+  for (const key in elementStyleB) {
+    expect(`${key}: ${elementStyleB[key]}`).toEqual(
+      `${key}: ${elementStyleA[key]}`
+    )
+  }
+
+  for (let index = 0; index < elementA.children.length; index++) {
+    expectElementMatches(elementA.children[index], elementB.children[index])
+  }
+}
+
+export const expectMatchingStyles = (
+  screen: RenderResult,
+  html: (html: typeof String.raw) => string,
+  css: (css: typeof String.raw) => string
+) => {
+  const htmlInput = html(String.raw) ?? ''
+  const cssInput = css(String.raw) ?? ''
+
+  // open a new tab
+  // we use two blank tabs to compare because vitest will insert its own styles
+  // which will cause the styles to not match
+  const nativeTab = window.open(
+    'about:blank',
+    '_blank',
+    `width=${window.innerWidth},height=${window.innerHeight}`
+  )
+  const restyleTab = window.open(
+    'about:blank',
+    '_blank',
+    `width=${window.innerWidth},height=${window.innerHeight}`
+  )
+  if (!nativeTab) throw new Error('failed to open new tab')
+  if (!restyleTab) throw new Error('failed to open new tab')
+
+  // inject the html and css into the new tab
+  const nativeStyle = nativeTab.document.createElement('style')
+  nativeStyle.innerHTML = cssInput
+  nativeTab.document.head.appendChild(nativeStyle)
+  nativeTab.document.body.innerHTML = htmlInput
+
+  // copy the test content into our second tab
+  restyleTab.document.body.innerHTML = screen.container.innerHTML
+  const restyles = document.querySelectorAll('style[data-precedence')
+  for (const style of restyles) {
+    restyleTab.document.head.appendChild(style.cloneNode(true))
+  }
+
+  expectElementMatches(restyleTab.document.body, nativeTab.document.body)
+
+  // close the tabs
+  nativeTab.close()
+  restyleTab.close()
+}


### PR DESCRIPTION
manage composition by _literally_ merging styles when we compose

- keep track of the styles each class name corresponds to
- when we render composed styles, use our classNames to retrieve the original styles for the extended component
- deeply merge these into our new styles

fixes #30 

one issue with my initial approach is that this could generate incorrect styles if the components ran in different environments. for example:
```typescript
// client.ts
"use client"

import { styled } from "restyle"

export const A = styled("div", {
  color: "green",
})

```
``` typescript
// server.ts
import { styled } from "restyle"
import { A } from "./client"

const B = styled("div", {
  color: "red",
})

const C = styled(A, {
  color: "red",
})

export default function Page() {
  return (
    <div style={{ gridColumn: "main", fontSize: "200px" }}>
      <B>Red</B>
      <A>Green</A>
      <C>Red</C>
    </div>
  )
}

```

We can get around this by sending _all_ our styles to the client. Worth noting that our styles are sent to the client at least twice, three times.

for server components:
- our CSS is included in the SSRed head
- our CSS as a string will be serialized and sent as a prop (this could be removed if CSS generation moved fully to the client, but I think we would need to change the way classNames are generated? not sure)
- after this change, our CSS object will _also_ be serialized and sent as a prop

for client components nothing changes:
- our CSS is included in the SSRed head
- our source code includes the CSS (obviously)