### PR TITLE
fix nested comma selector resolution

### DIFF
--- a/src/create-rules.test.ts
+++ b/src/create-rules.test.ts
@@ -132,4 +132,115 @@ describe('createRules', () => {
       ]
     `)
   })
+
+  it('handles comma-separated selectors without explicit nesting selectors', () => {
+    const result = createRules({
+      '.x, .y': {
+        color: 'red',
+      },
+    })
+    expect(result).toMatchInlineSnapshot(`
+      [
+        "hibl5h4",
+        [
+          [],
+          [],
+          [],
+          [
+            [
+              [],
+              [],
+              [
+                [
+                  "hibl5h4",
+                  ".hibl5h4 .x, .hibl5h4 .y{color:red}",
+                ],
+              ],
+              [],
+            ],
+          ],
+        ],
+      ]
+    `)
+  })
+
+  it('handles nested comma-separated selectors as cartesian products', () => {
+    const result = createRules({
+      '&.a, &.b': {
+        '& .x, & .y': {
+          color: 'red',
+        },
+      },
+    })
+    expect(result).toMatchInlineSnapshot(`
+      [
+        "hfsxhbn",
+        [
+          [],
+          [],
+          [],
+          [
+            [
+              [],
+              [],
+              [],
+              [
+                [
+                  [],
+                  [],
+                  [
+                    [
+                      "hfsxhbn",
+                      ".hfsxhbn.a .x, .hfsxhbn.a .y, .hfsxhbn.b .x, .hfsxhbn.b .y{color:red}",
+                    ],
+                  ],
+                  [],
+                ],
+              ],
+            ],
+          ],
+        ],
+      ]
+    `)
+  })
+
+  it('handles nested comma-separated selectors without explicit nesting selectors', () => {
+    const result = createRules({
+      '&.a, &.b': {
+        '.x, .y': {
+          color: 'red',
+        },
+      },
+    })
+    expect(result).toMatchInlineSnapshot(`
+      [
+        "hfsxhbn",
+        [
+          [],
+          [],
+          [],
+          [
+            [
+              [],
+              [],
+              [],
+              [
+                [
+                  [],
+                  [],
+                  [
+                    [
+                      "hfsxhbn",
+                      ".hfsxhbn.a .x, .hfsxhbn.a .y, .hfsxhbn.b .x, .hfsxhbn.b .y{color:red}",
+                    ],
+                  ],
+                  [],
+                ],
+              ],
+            ],
+          ],
+        ],
+      ]
+    `)
+  })
 })

--- a/src/create-rules.ts
+++ b/src/create-rules.ts
@@ -4,7 +4,14 @@ import type {
   CSSRulePrecedences,
   CSSValue,
 } from './types.js'
-import { resolveNestedSelector, l, m, u, hash } from './utils.js'
+import {
+  resolveNestedSelector,
+  splitSelectorList,
+  l,
+  m,
+  u,
+  hash,
+} from './utils.js'
 
 /** Create a single CSS rule from a CSS object. */
 export function createRule(
@@ -20,8 +27,9 @@ export function createRule(
   } else if (selector.includes('&')) {
     className = selector.replaceAll('&', '.' + name)
   } else {
-    className =
-      '.' + name + (selector.startsWith(':') ? selector : ' ' + selector)
+    className = splitSelectorList(selector)
+      .map((part) => '.' + name + (part.startsWith(':') ? part : ' ' + part))
+      .join(', ')
   }
 
   const hyphenProp = prop.replace(/[A-Z]|^ms/g, '-$&').toLowerCase()

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -76,14 +76,86 @@ export function hash(value: string): string {
   return h.toString(36)
 }
 
+/** Split a comma-separated selector list while preserving nested function and attribute commas. */
+export function splitSelectorList(selector: string): string[] {
+  const selectors: string[] = []
+  let current = ''
+  let depth = 0
+  let quote = ''
+
+  for (let index = 0; index < selector.length; index++) {
+    const char = selector[index]
+
+    if (quote) {
+      current += char
+
+      if (char === '\\') {
+        current += selector[++index] ?? ''
+      } else if (char === quote) {
+        quote = ''
+      }
+
+      continue
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char
+      current += char
+      continue
+    }
+
+    if (char === '(' || char === '[') {
+      depth++
+      current += char
+      continue
+    }
+
+    if (char === ')' || char === ']') {
+      depth--
+      current += char
+      continue
+    }
+
+    if (char === ',' && depth === 0) {
+      selectors.push(current.trim())
+      current = ''
+      continue
+    }
+
+    current += char
+  }
+
+  selectors.push(current.trim())
+  return selectors
+}
+
+function resolveSelectorPart(key: string, selector: string) {
+  if (key.includes('&')) {
+    return key.replaceAll('&', selector)
+  }
+
+  if (key.startsWith(':') || key.startsWith('::')) {
+    return selector + key
+  }
+
+  return selector + ' ' + key
+}
+
 /** Resolve a nested selector. */
 export function resolveNestedSelector(key: string, selector: string) {
-  if (key.includes('&')) {
-    return selector ? key.replaceAll('&', selector) : key
-  } else if (key.startsWith(':') || key.startsWith('::')) {
-    return selector + key
-  } else if (selector) {
-    return selector + ' ' + key
+  if (!selector) {
+    return key
   }
-  return key
+
+  const parents = splitSelectorList(selector)
+  const children = splitSelectorList(key)
+  const selectors: string[] = []
+
+  for (const parent of parents) {
+    for (const child of children) {
+      selectors.push(resolveSelectorPart(child, parent))
+    }
+  }
+
+  return selectors.join(', ')
 }


### PR DESCRIPTION
### Motivation
- Nested comma-separated selectors were resolving incorrectly and produced standalone parent selectors (e.g. `.h1a2b3.a` without its child), causing styles to apply more broadly than intended.
- The goal is to treat comma-separated parent and child selectors as a cartesian product so each parent combines with each child selector.

### Description
- Added `splitSelectorList` in `src/utils.ts` to split selector lists on top-level commas while preserving commas inside functions, attributes, and quoted strings, and added `resolveSelectorPart` to help combine parts.
- Reworked `resolveNestedSelector` in `src/utils.ts` to compute the cartesian product of parent and child selector lists using `splitSelectorList` and join the results with `, `.
- Updated `createRule` in `src/create-rules.ts` to apply the generated class prefix to every selector part returned from `splitSelectorList` and added regression tests in `src/create-rules.test.ts` covering root comma-separated selectors and nested comma-separated selectors (with and without `&`).

### Testing
- Ran `pnpm exec tsc --pretty false` and type checks passed successfully.
- Ran `pnpm exec vitest src/create-rules.test.ts --run --browser.enabled=false` and all tests passed (`6 tests`).
- Running the full `pnpm test src/create-rules.test.ts --run` triggered a Playwright environment error in CI due to missing browser binaries (expected environment warning), not related to the logic changes.

closes #52